### PR TITLE
thrift-lib: introduce socket channel and accompanying tests

### DIFF
--- a/common/util/Util/Binary/Parser.hs
+++ b/common/util/Util/Binary/Parser.hs
@@ -7,6 +7,7 @@
 module Util.Binary.Parser
   ( Parser
   , parse
+  , parseAndLeftover
   , peekBS
   , anyWord8
   , word8
@@ -148,6 +149,11 @@ parse getter bs =
   case eitherA of
     Right a -> Right a
     Left err -> Left (show err)
+
+parseAndLeftover
+  :: Parser a -> ByteString -> Either String (a, ByteString)
+parseAndLeftover p bs = parse p' bs
+  where p' = (,) <$> p <*> peekBS
 
 peekBS :: Parser ByteString
 peekBS = get

--- a/lib/Thrift/Channel/SocketChannel.hs
+++ b/lib/Thrift/Channel/SocketChannel.hs
@@ -1,0 +1,147 @@
+{-# LANGUAGE CPP, ScopedTypeVariables #-}
+module Thrift.Channel.SocketChannel
+  ( -- * Socket channel types and API
+    SocketChannel(..)
+  , SocketConfig(..)
+  , withSocketChannel
+  , withSocketChannelIO
+
+  , -- * Utilities used by test servers
+    sendBS
+  , teardownSock
+  , threadWaitRecv
+  , recvBlockBytes
+  , localhost
+  ) where
+
+import Control.Concurrent
+import Control.Exception
+import Control.Monad
+import Data.Maybe
+import Data.Proxy
+import Network.Socket
+import Network.Socket.ByteString
+import System.Posix.Types (Fd(..))
+import System.Timeout
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
+import qualified Data.Text as T
+
+import Thrift.Binary.Parser
+import Thrift.Channel
+import Thrift.Channel.HeaderChannel
+import Thrift.Monad
+import Thrift.Processor
+import Thrift.Protocol
+import Thrift.Protocol.ApplicationException.Types
+import Thrift.Protocol.Id
+
+newtype SocketChannel t = SocketChannel Socket
+
+instance ClientChannel SocketChannel where
+  sendRequest ch@(SocketChannel sock) req sendcb recvcb = do
+    sendOnewayRequest ch req sendcb
+    proceed
+
+    where msg = reqMsg req
+          n   = BS.length msg
+          proceed = do
+            recvRes <- try (threadWaitRecv sock recvBlockBytes)
+            case recvRes of
+              Right s -> recvcb (Right $ Response s mempty)
+              Left (e :: SomeException) -> recvcb (Left $ ChannelException $ T.pack (show e))
+
+  sendOnewayRequest (SocketChannel sock) req sendcb = do
+    res <- sendBS sock (reqMsg req)
+    sendcb res
+
+data SocketConfig a = SocketConfig
+  { socketHost       :: HostName
+  , socketPortNum    :: PortNumber
+  , socketProtocolId :: ProtocolId
+  }
+
+deriving instance Show (SocketConfig a)
+
+-- | Given a 'SocketConfig' that specifies where to find the
+--   server we want to reach and what protocol it uses,
+--   connect to the server and run the given client
+--   computation with it.
+withSocketChannel
+  :: SocketConfig t
+  -> (forall p . Protocol p => ThriftM p SocketChannel t a)
+  -> IO a
+withSocketChannel SocketConfig{..} f =
+  withSocketChannelIO socketHost socketPortNum $ \ch -> do
+    withProxy socketProtocolId (go ch f)
+
+  where go :: Protocol p
+           => SocketChannel t
+           -> ThriftM p SocketChannel t a
+           -> Proxy p
+           -> IO a
+        go ch f _proxy = runThrift f ch
+
+-- | A lower level variant of 'withSocketChannel' that connects
+--   to the server at the given host and port and passes the
+--   resulting 'SocketChannel' to the third argument.
+withSocketChannelIO
+  :: HostName
+  -> PortNumber
+  -> (SocketChannel t -> IO a)
+  -> IO a
+withSocketChannelIO host port f = withSocketClient host port $ \sock _ ->
+  f (SocketChannel sock)
+
+sendBS :: Socket -> BS.ByteString -> IO (Maybe ChannelException)
+sendBS sock bs = try (sendAll sock bs) >>= \res -> case res of
+  Left  e -> return (Just e)
+  Right _ -> return Nothing
+
+-- | Block (using 'threadWaitRead') until some data is available,
+--   and then call 'recv' to grab it.
+threadWaitRecv
+  :: Socket
+  -> Int -- ^ max. number of bytes we want to receive
+  -> IO BS.ByteString
+threadWaitRecv sock numBytes = withFdSocket sock $ \fd ->
+  threadWaitRead (Fd fd) >> recv sock numBytes
+
+withSocketClient
+  :: HostName
+  -> PortNumber
+  -> (Socket -> AddrInfo -> IO a)
+  -> IO a
+withSocketClient host port f = withSocketsDo $ do
+  addr <- resolveClient host port
+  bracket (setupClientSock addr) teardownSock $ \sock ->
+    f sock addr
+
+setupClientSock :: AddrInfo -> IO Socket
+setupClientSock addr = do
+  s <- openSocket addr
+  connect s (addrAddress addr)
+  return s
+
+teardownSock :: Socket -> IO ()
+teardownSock sock = shutdown sock ShutdownBoth `finally` close sock
+
+resolveClient :: HostName -> PortNumber -> IO AddrInfo
+resolveClient host port = do
+  results <- getAddrInfo (Just hints) (Just host) (Just $ show port)
+  case results of
+    [] -> error "SocketChannel.resolveClient: getAddrInfo returned an empty list"
+    (a:_) -> return a
+
+  where hints = defaultHints { addrSocketType = Stream }
+
+localhost :: HostName
+localhost =
+#ifdef IPV4
+  "127.0.0.1"
+#else
+  "::1"
+#endif
+
+recvBlockBytes :: Int
+recvBlockBytes = 4096

--- a/lib/test/ClientTest.hs
+++ b/lib/test/ClientTest.hs
@@ -12,22 +12,20 @@ import Data.Proxy
 import TestRunner
 import Test.HUnit hiding (State)
 
-import Math.Types
-import Math.Adder.Client
-import Math.Adder.Service
-import Math.Calculator.Client
-import Math.Calculator.Service
-
-import TestChannel
 import Thrift.Channel
 import Thrift.Monad
 import Thrift.Protocol
 import Thrift.Protocol.ApplicationException.Types
 import Thrift.Protocol.Binary
 
-mkClientTest :: String -> ThriftM Binary TestChannel Calculator () -> Test
-mkClientTest label =
-  mkClientTestWith label defaultRpcOptions
+import Math.Types
+import Math.Adder.Client
+import Math.Adder.Service
+import Math.Calculator.Client
+import Math.Calculator.Service
+
+import TestCommon
+import TestChannel
 
 mkClientTestWith
   :: String -> RpcOptions -> ThriftM Binary TestChannel Calculator () -> Test
@@ -39,54 +37,10 @@ mkClientTestWith label opts action = TestLabel label $ TestCase $ do
     let env = ThriftEnv proxy channel opts counter
     runReaderT action env
 
-addTest :: Test
-addTest = mkClientTest "add test" $ do
-  result <- add 5 2
-  lift $ assertEqual "5 + 2 = 7" 7 result
-
-divTest :: Test
-divTest = mkClientTest "divide test" $ do
-  result <- divide 10 2
-  lift $ assertEqual "10 / 2 = 5" 5 result
-
-putGetTest :: Test
-putGetTest = mkClientTest "put get" $ do
-  let value = 99
-  put value
-  result <- get
-  lift $ assertEqual "put 99 = get" value result
-
-exceptionTest :: Test
-exceptionTest = mkClientTest "exception test" $
-  (void . lift . evaluate =<< divide 0 0)
-    `catchThrift` \DivideByZero -> return ()
-
-optionsTest :: Test
-optionsTest = mkClientTestWith "options test" opts $
-  (void . lift . evaluate =<< (add 0 0 *> error "fail"))
-    `catchThrift` \ChannelException{} -> return ()
-  where
-    opts = setRpcPriority defaultRpcOptions High
-
-unimplementedTest :: Test
-unimplementedTest = mkClientTest "unimplemented test" $
-  unimplemented `catchThrift` \ApplicationException{} -> return ()
-
-multiTest :: Test
-multiTest = mkClientTest "multiple requests" $ do
-  r1 <- add 2 2
-  lift $ assertEqual "2 + 2 = 4" 4 r1
-
-  r2 <- divide 64 16
-  lift $ assertEqual "64 / 16 = 4" 4 r2
-
-  put 100
-  r3 <- get
-  lift $ assertEqual "put = get" 100 r3
-
 main :: IO ()
-main = testRunner $ TestList
-       [ addTest, divTest, putGetTest
+main = testRunner . TestList $
+  runChannelTests mkClientTestWith
+       [ addTest, divTest, putGetTest, putPutGetTest
        , exceptionTest, optionsTest, unimplementedTest, multiTest ]
 
 -- Server Implementation -------------------------------------------------------
@@ -96,20 +50,3 @@ runCalculatorServer :: Protocol p => Proxy p -> TestChannel Calculator -> IO ()
 runCalculatorServer proxy ch = do
   state  <- initServerState
   runServer proxy ch $ processCommand state
-
--- Server Implementation
-type State = IORef Int
-
-initServerState :: IO State
-initServerState = newIORef 0
-
-processCommand :: State -> CalculatorCommand a -> IO a
-processCommand _ (SuperAdder (Add x y)) = pure $ x + y
-processCommand _ (Divide x y)
-  | y == 0    = throwIO DivideByZero
-  | otherwise = pure $ x / y
-processCommand state (Put x) = writeIORef state x
-processCommand state (PutMany xs) = mapM_ (writeIORef state) xs
-processCommand state Get = readIORef state
-processCommand _ Unimplemented =
-  throw $ ApplicationException "" ApplicationExceptionType_UnknownMethod

--- a/lib/test/ServerChannel.hs
+++ b/lib/test/ServerChannel.hs
@@ -1,0 +1,1 @@
+module ServerChannel where

--- a/lib/test/SocketChannelTest.hs
+++ b/lib/test/SocketChannelTest.hs
@@ -1,0 +1,52 @@
+module SocketChannelTest where
+
+import Control.Concurrent
+import Control.Exception hiding (DivideByZero)
+import Control.Monad
+import Control.Monad.Trans.Class
+import Control.Monad.Trans.Reader
+import Data.IORef
+import Data.Proxy
+import TestRunner
+import Test.HUnit hiding (State)
+
+import Thrift.Api
+import Thrift.Channel
+import Thrift.Channel.SocketChannel as Sock
+import Thrift.Monad
+import Thrift.Protocol
+import Thrift.Protocol.ApplicationException.Types
+import Thrift.Protocol.Binary
+import Thrift.Protocol.Id
+
+import Math.Types
+import Math.Adder.Client
+import Math.Adder.Service
+import Math.Calculator.Client
+import Math.Calculator.Service
+
+import SocketServer
+import TestCommon
+
+main :: IO ()
+main = testRunner . TestList $
+  runChannelTests mkClientTestSockWith
+       [ addTest, divTest, putGetTest, putPutGetTest
+       , exceptionTest, unimplementedTest, multiTest ]
+
+-- Client utilities ------------------------------------------------------------
+
+mkClientTestSock
+  :: String
+  -> Thrift Calculator ()
+  -> Test
+mkClientTestSock lbl = mkClientTestSockWith lbl defaultRpcOptions
+
+mkClientTestSockWith
+  :: String
+  -> RpcOptions
+  -> Thrift Calculator ()
+  -> Test
+mkClientTestSockWith lbl opts action = TestLabel lbl $ TestCase $ do
+  state <- initServerState
+  withServer binaryProtocolId (processCommand state) action

--- a/lib/test/SocketServer.hs
+++ b/lib/test/SocketServer.hs
@@ -1,0 +1,174 @@
+module SocketServer
+  ( withServer
+  , runServer
+  ) where
+
+import Control.Concurrent
+import Control.Concurrent.Async
+import Control.Exception
+import Control.Monad
+import Data.ByteString.Builder (toLazyByteString)
+import Data.ByteString.Lazy (toStrict)
+import Data.Proxy
+import Network.Socket
+import Network.Socket.ByteString
+import qualified Data.ByteString as BS
+import qualified Data.Text as T
+
+import Thrift.Api
+import Thrift.Binary.Parser
+import Thrift.Channel.SocketChannel
+import Thrift.Monad
+import Thrift.Processor
+import Thrift.Protocol
+import Thrift.Protocol.ApplicationException.Types
+import Thrift.Protocol.Id
+
+
+-- | A high level function for running a Thrift server and some
+--   client computations against it, using the given handler to
+--   process requests.
+withServer
+  :: Processor s
+  => ProtocolId               -- ^ protocol to use
+  -> (forall a . s a -> IO a) -- ^ server-side request handler
+  -> Thrift t ()              -- ^ client computation
+  -> IO ()
+withServer protocol hndl action =
+  withProxy protocol $ \proxy ->
+    runServer proxy hndl $ \port ->
+      withSocketChannel
+        (SocketConfig localhost (fromIntegral port) protocol)
+        action
+
+-- | Bring up a server that will handle requests with the given handler,
+--   and run client computations against it. 'Int' argument is the port
+--   that the server found to be available and ended up listening on.
+runServer
+  :: forall c p. (Processor c, Protocol p)
+  => Proxy p
+  -> (forall r. c r -> IO r) -- ^ server handler
+  -> (Int -> IO ())          -- ^ client computation
+  -> IO ()
+runServer p handler client  = do
+  counter <- newCounter
+  flip runTestServer (\sock -> client . fromIntegral =<< socketPort sock) $
+    \clientSock -> counter >>= \seqNum ->
+      handleClient seqNum counter Nothing clientSock
+
+  where handleClient seqNum counter mincompleteMsg sock =
+          handleProtocolException p sock seqNum $
+            handleClient' seqNum counter mincompleteMsg sock
+        handleClient' seqNum counter mincompleteMsg sock = do
+          minput <- try (threadWaitRecv sock recvBlockBytes)
+          case minput of
+            Left (e :: SomeException) -> do
+              throwProtocolException $ unwords
+                [ "an exception was raised while trying to read from"
+                , "the client socket: " ++ show e
+                ]
+            Right input
+              | BS.null input -> return ()
+              | otherwise -> do
+                  let input' = maybe input (<> input) mincompleteMsg
+                  (mincomplete', seqNum') <- processInput seqNum counter input' sock
+                  handleClient seqNum' counter mincomplete' sock
+
+        processInput seqNum counter input sock =
+          -- TODO: we'd perhaps like to know how much progress we make, to
+          --       distinguish bad input that we'll never be able to make sense
+          --       of, no matter how many more bytes we add to it, and
+          --       large commands that we receive in several chunks.
+          case parseAndLeftover (msgParser p) input of
+            -- 'input' is an incomplete command, we keep it around
+            -- to add more bytes to it before attempting to parse and
+            -- process it again
+            Left err -> return (Just input, seqNum)
+
+            -- 'input' contains at least a complete command, that we
+            -- process. If there's some leftover, we try and extract
+            -- a command from it as well, potentially doing this several
+            -- times, until either we're done or more input is needed to go
+            -- further.
+            Right (This cmd, leftover) -> do
+              (response, mexc) <- processCommand p seqNum handler cmd
+              seqNum' <- counter
+              case mexc of
+                Just (_exc, _blame) -> do
+                  sendBS sock (toStrict $ toLazyByteString response)
+                  return (Nothing, seqNum')
+                Nothing -> do
+                  unless (reqName cmd `elem` onewayFns (Proxy :: Proxy c)) $
+                    sendBS sock (toStrict $ toLazyByteString response) >> return ()
+                  case BS.null leftover of
+                    True  -> return (Nothing, seqNum')
+                    False -> processInput seqNum' counter leftover sock
+
+sendException
+  :: Protocol p => Proxy p -> Socket -> SeqNum -> ApplicationException -> IO ()
+sendException proxy sock seqNum exc =
+  sendBS sock protocolExcMsg >> return ()
+
+  where protocolExcMsg = toStrict . toLazyByteString $
+          genMsgBegin proxy "" 3 seqNum <>
+          buildStruct proxy exc <>
+          genMsgEnd proxy
+
+handleProtocolException
+  :: Protocol p
+  => Proxy p
+  -> Socket
+  -> SeqNum
+  -> IO ()
+  -> IO ()
+handleProtocolException proxy sock seqNum m = m `catch` hndl
+  where hndl :: ApplicationException -> IO ()
+        hndl exc = sendException proxy sock seqNum exc
+
+throwProtocolException :: String -> IO a
+throwProtocolException err = throwIO (mkProtocolException err)
+
+mkProtocolException :: String -> ApplicationException
+mkProtocolException err = ApplicationException (T.pack err)
+  ApplicationExceptionType_ProtocolError
+
+runTestServer
+  :: (Socket -> IO ()) -- ^ server computation
+  -> (Socket -> IO ()) -- ^ client computation
+  -> IO ()
+runTestServer server client = do
+  withSocketServer maxListenQueue
+    (\servSock _sa -> client servSock)
+    (\sock _sa -> server sock)
+
+withSocketServer
+  :: Int                           -- maximum number of queued connections
+  -> (Socket -> SockAddr -> IO ()) -- what to do when the server is up
+  -> (Socket -> SockAddr -> IO ()) -- what to do on a new client connection
+  -> IO ()
+withSocketServer maxQueuedConns onServerUp onNewClient = withSocketsDo $ do
+  addr <- resolveServer localhost
+  bracket (setupServerSock maxQueuedConns addr) teardownSock $ \sock ->
+    withAsync (acceptLoop sock) $ \_async ->
+      onServerUp sock (addrAddress addr)
+
+  where acceptLoop sock = forever $ do
+          (clientSock, clientAddr) <- accept sock
+          forkFinally (onNewClient clientSock clientAddr)
+                      (\_res -> mask_ $ teardownSock clientSock)
+
+setupServerSock :: Int -> AddrInfo -> IO Socket
+setupServerSock maxQueuedConns addr = do
+  s <- openSocket addr
+  bind s (addrAddress addr)
+  listen s maxQueuedConns
+  return s
+
+resolveServer :: HostName -> IO AddrInfo
+resolveServer host = do
+  results <- getAddrInfo (Just hints) (Just host) Nothing
+  case results of
+    [] -> error "SocketServer.resolveServer: getAddrInfo returned an empty list"
+    (a:_) -> return a
+
+  where hints = defaultHints { addrSocketType = Stream }

--- a/lib/test/TestCommon.hs
+++ b/lib/test/TestCommon.hs
@@ -1,0 +1,124 @@
+module TestCommon where
+
+import Control.Exception (throw, throwIO, evaluate)
+import Control.Monad
+import Control.Monad.Trans.Class
+import Data.IORef
+import TestRunner
+import Test.HUnit hiding (State)
+
+import Thrift.Api
+import Thrift.Channel
+import Thrift.Monad
+import Thrift.Protocol
+import Thrift.Protocol.ApplicationException.Types
+
+import Math.Types
+import Math.Adder.Client
+import Math.Adder.Service
+import Math.Calculator.Client
+import Math.Calculator.Service
+
+-- Server Implementation for the 'Calculator' service
+
+type State = IORef Int
+
+initServerState :: IO State
+initServerState = newIORef 0
+
+processCommand :: State -> CalculatorCommand a -> IO a
+processCommand _ (SuperAdder (Add x y)) = pure $ x + y
+processCommand _ (Divide x y)
+  | y == 0    = throwIO DivideByZero
+  | otherwise = pure $ x / y
+processCommand state (Put x) = writeIORef state x
+processCommand state (PutMany xs) = mapM_ (writeIORef state) xs
+processCommand state Get = readIORef state
+processCommand _ Unimplemented =
+  throw $ ApplicationException "" ApplicationExceptionType_UnknownMethod
+
+
+-- common client computations/tests used with diffeerent channel implementations
+
+-- if needed, this 'Calculator' could just become a type
+-- parameter, in case such utilities are needed for other
+-- test suites.
+data ChannelTest = ChannelTest
+  { ctestName :: String
+  , ctestOpts :: RpcOptions
+  , ctestAct  :: Thrift Calculator ()
+  }
+
+-- | Package up a test label and the corresponding client
+--   computation, to later be executed against a specific
+--   channel implementation and server.
+channelTest
+  :: String -> Thrift Calculator () -> ChannelTest
+channelTest lbl comp = channelTestWithOpts lbl defaultRpcOptions comp
+
+-- | Like 'channelTest', but with the ability to pass 'RpcOptions' to the
+--   test.
+channelTestWithOpts
+  :: String -> RpcOptions -> Thrift Calculator () -> ChannelTest
+channelTestWithOpts = ChannelTest
+
+runChannelTests
+  :: (String -> RpcOptions -> Thrift Calculator () -> Test)
+  -> [ChannelTest]
+  -> [Test]
+runChannelTests testFun tests =
+  map (\ChannelTest{..} -> testFun ctestName ctestOpts ctestAct) tests
+
+addTest :: ChannelTest
+addTest = channelTest "add test" $ do
+  result <- add 5 2
+  lift $ assertEqual "5 + 2 = 7" 7 result
+
+divTest :: ChannelTest
+divTest = channelTest "divide test" $ do
+  result <- divide 10 2
+  lift $ assertEqual "10 / 2 = 5" 5 result
+
+putGetTest :: ChannelTest
+putGetTest = channelTest "put get" $ do
+  let value = 99
+  put value
+  result <- get
+  lift $ assertEqual "put 99 = get" value result
+
+putPutGetTest :: ChannelTest
+putPutGetTest = channelTest "put put get" $ do
+  let value1 = 99
+      value2 = 100
+  put value1
+  put value2
+  result <- get
+  lift $ assertEqual "put 99 then put 100 = get (= put 100)" value2 result
+
+exceptionTest :: ChannelTest
+exceptionTest = channelTest "exception test" $
+  (void . lift . evaluate =<< divide 0 0)
+    `catchThrift` \DivideByZero -> return ()
+
+optionsTest :: ChannelTest
+optionsTest = channelTestWithOpts "options test" opts $
+  (void . lift . evaluate =<< (add 0 0 *> error "fail"))
+    `catchThrift` \ChannelException{} -> return ()
+  where
+    opts = setRpcPriority defaultRpcOptions High
+
+unimplementedTest :: ChannelTest
+unimplementedTest = channelTest "unimplemented test" $
+  unimplemented `catchThrift` \ApplicationException{} -> return ()
+
+multiTest :: ChannelTest
+multiTest = channelTest "multiple requests" $ do
+  r1 <- add 2 2
+  lift $ assertEqual "2 + 2 = 4" 4 r1
+
+  r2 <- divide 64 16
+  lift $ assertEqual "64 / 16 = 4" 4 r2
+
+  put 100
+  r3 <- get
+  lift $ assertEqual "put = get" 100 r3

--- a/lib/thrift-lib.cabal
+++ b/lib/thrift-lib.cabal
@@ -67,6 +67,7 @@ library
         Thrift.Channel
         Thrift.Channel.CppChannel
         Thrift.Channel.HeaderChannel
+        Thrift.Channel.SocketChannel
         Thrift.Protocol
         Thrift.Protocol.Compact
         Thrift.Protocol.Id
@@ -128,10 +129,16 @@ library
         base >=4.11.1 && <4.15,
         transformers ^>=0.5.5.0,
         bytestring ^>=0.10.8.2,
+        network,
         text ^>=1.2.3.0,
         unordered-containers ^>=0.2.9.0,
         hashable >=1.2.7.0 && <1.4,
         vector ^>=0.12.0.1
+
+    if flag(tests_use_ipv4)
+      -- for SocketChannel.hs
+      cpp-options: -DIPV4
+
 
 flag tests_use_ipv4
      description: Force tests to use IPV4 whenever bringing thrift clients/servers up
@@ -145,6 +152,7 @@ common test-common
         test/gen-hs2
   other-modules:
         Network
+        TestCommon
         TestRunner
         TestChannel
         Math.Types
@@ -152,6 +160,7 @@ common test-common
         Math.Calculator.Client
         Math.Adder.Service
         Math.Calculator.Service
+        SocketServer
         HsTest.Types
   include-dirs: .
   cxx-options:   -std=c++17
@@ -168,7 +177,8 @@ common test-common
         transport
         concurrency
         thrift-core
-  build-depends: base,
+  build-depends: async ^>= 2.2,
+                 base,
                  bytestring,
                  dependent-sum,
                  fb-util,
@@ -176,6 +186,7 @@ common test-common
                  hspec,
                  hspec-contrib,
                  HUnit ^>= 1.6.1,
+                 network,
                  text,
                  thrift-lib,
                  -- vvv for HsTest.Types
@@ -202,6 +213,12 @@ test-suite channel
   type: exitcode-stdio-1.0
   main-is: ChannelTest.hs
   ghc-options: -main-is ChannelTest
+
+test-suite socket-channel
+  import: fb-haskell, test-common
+  type: exitcode-stdio-1.0
+  main-is: SocketChannelTest.hs
+  ghc-options: -main-is SocketChannelTest
 
 test-suite client
   import: fb-haskell, test-common

--- a/server/test/ServerTest.hs
+++ b/server/test/ServerTest.hs
@@ -24,7 +24,6 @@ import Math.Calculator.Client
 import Math.Types
 import Echoer.Echoer.Client
 import EchoHandler
-
 import Thrift.Server.CppServer
 
 withTestServer :: ServerOptions -> (Int -> IO a) -> IO a


### PR DESCRIPTION
This is a preliminary implementation of socket-based channels in `thrift-lib`, which comes with similar tests as other channels.

@simonmar I'm sure there will be things to tweak, but with this branch as it is now, I can reliably and repeatedly get the tests to pass in CI _and_ on my machine.