### PR TITLE
Make a separate package for TestRunner and Facebook.Init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,34 +98,7 @@ thrift-cpp::
 		-o . \
 		hs_test.thrift
 
-# Copying around some common Haskell modules used
-# by many packages in their testsuites. Might
-# instead have all these common modules be exposed
-# by fb-util?
 copy-sources::
-	mkdir -p common/util/tests/github/Facebook \
-		 server/test/github/Facebook \
-		 common/mangle/tests/github \
-		 tests/github lib/test/github
-
-	cp common/github/Facebook/Init.hs \
-           common/util/tests/github/Facebook/
-	cp common/github/Facebook/Init.hs \
-           server/test/github/Facebook/
-
-	cp common/github/TestRunner.hs \
-	   common/mangle/tests/github/
-	cp common/github/TestRunner.hs \
-	   common/util/tests/github/
-	cp common/github/TestRunner.hs \
-	   tests/github/
-	cp common/github/TestRunner.hs \
-	   compiler/test/github/
-	cp common/github/TestRunner.hs \
-	   server/test/github/
-	cp common/github/TestRunner.hs \
-	   lib/test/github/
-
 	cp lib/test/Network.hs server/test/
 	cp lib/test/TestChannel.hs server/test/
 	cp lib/test/TestChannel.hs tests/

--- a/cabal.project
+++ b/cabal.project
@@ -2,6 +2,7 @@
 
 packages:
     common/util/fb-util.cabal
+    common/github/fb-stubs.cabal
     common/mangle/mangle.cabal
     lib/thrift-lib.cabal
     server/thrift-server.cabal

--- a/ci.cabal.project
+++ b/ci.cabal.project
@@ -2,6 +2,7 @@
 
 packages:
     common/util/fb-util.cabal
+    common/github/fb-stubs.cabal
     common/mangle/mangle.cabal
     compiler/thrift-compiler.cabal
     lib/thrift-lib.cabal

--- a/common/github/LICENSE
+++ b/common/github/LICENSE
@@ -1,0 +1,30 @@
+BSD License
+
+For hsthrift software
+
+Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name Facebook nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/common/github/fb-stubs.cabal
+++ b/common/github/fb-stubs.cabal
@@ -1,0 +1,64 @@
+cabal-version:       3.6
+
+-- Copyright (c) Facebook, Inc. and its affiliates.
+
+name:                fb-stubs
+version:             0.1.0.0
+synopsis:            Stubs for dependencies of test code
+homepage:            https://github.com/facebookincubator/hsthrift
+bug-reports:         https://github.com/facebookincubator/hsthrift/issues
+license:             BSD-3-Clause
+license-file:        LICENSE
+author:              Facebook, Inc.
+maintainer:          hsthrift-team@fb.com
+copyright:           (c) Facebook, All Rights Reserved
+category:            Utilities
+build-type:          Simple
+
+description:
+    NOTE: for build instructions, see
+    https://github.com/facebookincubator/hsthrift
+
+source-repository head
+    type: git
+    location: https://github.com/facebookincubator/hsthrift.git
+
+common fb-haskell
+    default-language: Haskell2010
+    default-extensions:
+        BangPatterns
+        BinaryLiterals
+        DataKinds
+        DeriveDataTypeable
+        DeriveGeneric
+        EmptyCase
+        ExistentialQuantification
+        FlexibleContexts
+        FlexibleInstances
+        GADTs
+        GeneralizedNewtypeDeriving
+        LambdaCase
+        MultiParamTypeClasses
+        MultiWayIf
+        NoMonomorphismRestriction
+        OverloadedStrings
+        PatternSynonyms
+        RankNTypes
+        RecordWildCards
+        ScopedTypeVariables
+        StandaloneDeriving
+        TupleSections
+        TypeFamilies
+        TypeSynonymInstances
+        NondecreasingIndentation
+
+library
+    import: fb-haskell
+
+    exposed-modules:
+        TestRunner
+        Facebook.Init
+
+    build-depends:
+        base >=4.11.1.0 && <4.15,
+        HUnit ^>= 1.6.1

--- a/common/mangle/mangle.cabal
+++ b/common/mangle/mangle.cabal
@@ -47,9 +47,9 @@ test-suite mangle-test
   default-language: Haskell2010
   default-extensions: LambdaCase
   main-is: Test.hs
-  other-modules: TestRunner
   build-depends:
       base,
+      fb-stubs,
       hspec,
       hspec-contrib,
       mangle,

--- a/common/util/fb-util.cabal
+++ b/common/util/fb-util.cabal
@@ -210,7 +210,7 @@ common test-common
   cxx-options: -std=c++17
   ghc-options: -threaded
   hs-source-dirs: tests, tests/github
-  other-modules: SpecRunner, TestRunner, Facebook.Init
+  other-modules: SpecRunner
   build-depends: base,
                  aeson,
                  async,
@@ -219,6 +219,7 @@ common test-common
                  containers,
                  directory,
                  fb-util,
+                 fb-stubs,
                  filepath,
                  hspec,
                  hspec-contrib,

--- a/compiler/thrift-compiler.cabal
+++ b/compiler/thrift-compiler.cabal
@@ -125,13 +125,13 @@ test-suite thrift-compiler-tests
   hs-source-dirs: test, test/github
   main-is: TestFixtures.hs
   ghc-options: -threaded -main-is TestFixtures
-  other-modules: TestRunner
-                 Util
+  other-modules: Util
   build-depends: aeson-pretty,
                  base,
                  directory,
                  extra,
                  filepath,
+                 fb-stubs,
                  haskell-src-exts >=1.20.3 && <1.24,
                  hspec,
                  hspec-contrib,

--- a/lib/thrift-lib.cabal
+++ b/lib/thrift-lib.cabal
@@ -165,7 +165,6 @@ common test-common
   other-modules:
         Network
         TestCommon
-        TestRunner
         TestChannel
         Math.Types
         Math.Adder.Client
@@ -193,6 +192,7 @@ common test-common
                  base,
                  bytestring,
                  dependent-sum,
+                 fb-stubs,
                  fb-util,
                  filepath,
                  hspec,

--- a/server/thrift-server.cabal
+++ b/server/thrift-server.cabal
@@ -98,9 +98,7 @@ flag tests_use_ipv4
 common test-common
   hs-source-dirs: test, test/github, test/gen-hs2
 
-  other-modules: Facebook.Init
-                 Network
-                 TestRunner
+  other-modules: Network
                  CalculatorHandler
                  EchoHandler
                  Echoer.Echoer.Client
@@ -117,6 +115,7 @@ common test-common
                  bytestring,
                  data-default,
                  deepseq,
+                 fb-stubs,
                  fb-util,
                  hashable,
                  hspec,

--- a/tests/thrift-tests.cabal
+++ b/tests/thrift-tests.cabal
@@ -61,7 +61,6 @@ common fb-haskell
 
 common test-common
   hs-source-dirs: ., github/, gen-hs2/
-  other-modules: TestRunner
   -- include-dirs: .
   -- cxx-options: -std=c++17
   -- cxx-sources: cpp/hs_test.cpp
@@ -74,6 +73,7 @@ common test-common
                  data-default,
                  deepseq,
                  either,
+                 fb-stubs,
                  hashable,
                  hspec,
                  hspec-contrib,


### PR DESCRIPTION
Avoid having to copy these files around, reducing Makefile magic.