### PR TITLE
Write JSON files with deterministic key ordering

### DIFF
--- a/compiler/Thrift/Compiler/GenJSON.hs
+++ b/compiler/Thrift/Compiler/GenJSON.hs
@@ -39,11 +39,12 @@ writeJSON
   -> IO FilePath
 writeJSON prog@Program{..} deps = do
   createDirectoryIfMissing True dir
-  LBS.writeFile path $ encodePretty $ genJSON prog deps
+  LBS.writeFile path $ prettyJSON $ genJSON prog deps
   return path
   where
     path = dir </> file
     (dir, file) = getAstPath prog
+    prettyJSON = encodePretty' defConfig { confCompare = compare }
 
 getAstPath :: Program l a -> (FilePath, FilePath)
 getAstPath Program{..} = (progOutPath, Text.unpack progName ++ ".ast")

--- a/compiler/Thrift/Compiler/GenJSONLoc.hs
+++ b/compiler/Thrift/Compiler/GenJSONLoc.hs
@@ -44,11 +44,12 @@ writeJSONLoc
   -> IO FilePath
 writeJSONLoc prog@Program{..} deps = do
   createDirectoryIfMissing True dir
-  LBS.writeFile path $ encodePretty $ genJSONLoc prog deps
+  LBS.writeFile path $ prettyJSON $ genJSONLoc prog deps
   return path
   where
     path = dir </> file
     (dir, file) = getAstPathLoc prog
+    prettyJSON = encodePretty' defConfig { confCompare = compare }
 
 getAstPathLoc :: Program l a -> (FilePath, FilePath)
 getAstPathLoc Program{..} = (progOutPath, Text.unpack progName ++ ".ast")

--- a/compiler/test/TestFixtures.hs
+++ b/compiler/test/TestFixtures.hs
@@ -49,16 +49,19 @@ genFixtures (TheseOptions opts@Options{..}) = do
         | otherwise -> return $ map (genJSONLocThriftModule Nothing)
                               $ prog : deps
       _ -> return []
+
+    prettyJSON = encodePretty' defConfig { confCompare = compare }
+
     genJSONThriftModule ds prog = ThriftModule
       { tmPath = uncurry (</>) $ getAstPath prog
       , tmContents =
-          Text.unpack $ Text.decodeUtf8 $ encodePretty $ genJSON prog ds
+          Text.unpack $ Text.decodeUtf8 $ prettyJSON $ genJSON prog ds
       , tmModuleName = ""
       }
     genJSONLocThriftModule ds prog = ThriftModule
       { tmPath = uncurry (</>) $ getAstPath prog
       , tmContents =
-          Text.unpack $ Text.decodeUtf8 $ encodePretty $ genJSONLoc prog ds
+          Text.unpack $ Text.decodeUtf8 $ prettyJSON $ genJSONLoc prog ds
       , tmModuleName = ""
       }
 

--- a/compiler/test/fixtures/gen-basic-loc/a.ast
+++ b/compiler/test/fixtures/gen-basic-loc/a.ast
@@ -1,251 +1,6 @@
 {
-    "typedefs": [
-        {
-            "newtype": false,
-            "anns": null,
-            "ann_type": {
-                "anns": null,
-                "loc": [
-                    "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 9, locEndLine = 7, locEndCol = 12}"
-                ],
-                "type": {
-                    "type": "i64"
-                }
-            },
-            "xref": [],
-            "name": "T",
-            "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 13, locEndLine = 7, locEndCol = 14}",
-            "type": {
-                "type": "i64"
-            },
-            "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 1, locEndLine = 7, locEndCol = 8}"
-        }
-    ],
-    "structs": [
-        {
-            "name": "A",
-            "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 9, locStartCol = 8, locEndLine = 9, locEndCol = 9}",
-            "struct_type": "STRUCT",
-            "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 9, locStartCol = 1, locEndLine = 9, locEndCol = 7}",
-            "fields": [
-                {
-                    "default_value": {
-                        "named_constant": {
-                            "name": "a"
-                        }
-                    },
-                    "xref": [
-                        {
-                            "rLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 13, locEndLine = 7, locEndCol = 14}",
-                            "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 10, locStartCol = 6, locEndLine = 10, locEndCol = 7}"
-                        }
-                    ],
-                    "name": "a",
-                    "requiredness": "default",
-                    "id": 1,
-                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 10, locStartCol = 8, locEndLine = 10, locEndCol = 9}",
-                    "type": {
-                        "inner_type": {
-                            "type": "i64"
-                        },
-                        "name": {
-                            "name": "T"
-                        },
-                        "loc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 13, locEndLine = 7, locEndCol = 14}",
-                        "type": "typedef"
-                    }
-                },
-                {
-                    "default_value": {
-                        "named_constant": {
-                            "name": "b"
-                        }
-                    },
-                    "xref": [
-                        {
-                            "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
-                            "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 11, locStartCol = 6, locEndLine = 11, locEndCol = 9}"
-                        }
-                    ],
-                    "name": "b",
-                    "requiredness": "default",
-                    "id": 2,
-                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 11, locStartCol = 10, locEndLine = 11, locEndCol = 11}",
-                    "type": {
-                        "name": {
-                            "name": "B",
-                            "src": "b"
-                        },
-                        "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
-                        "type": "struct"
-                    }
-                },
-                {
-                    "default_value": {
-                        "named_constant": {
-                            "name": "bool_value",
-                            "src": "b"
-                        }
-                    },
-                    "xref": [],
-                    "name": "c",
-                    "requiredness": "default",
-                    "id": 3,
-                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 12, locStartCol = 11, locEndLine = 12, locEndCol = 12}",
-                    "type": {
-                        "type": "bool"
-                    }
-                },
-                {
-                    "xref": [],
-                    "name": "d",
-                    "requiredness": "default",
-                    "id": 4,
-                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 13, locStartCol = 22, locEndLine = 13, locEndCol = 23}",
-                    "type": {
-                        "inner_type": {
-                            "inner_type": {
-                                "type": "i32"
-                            },
-                            "type": "list"
-                        },
-                        "type": "list"
-                    }
-                },
-                {
-                    "xref": [],
-                    "name": "e",
-                    "requiredness": "default",
-                    "id": 5,
-                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 14, locStartCol = 23, locEndLine = 14, locEndCol = 24}",
-                    "type": {
-                        "val_type": {
-                            "type": "string"
-                        },
-                        "key_type": {
-                            "type": "i32"
-                        },
-                        "type": "map"
-                    }
-                },
-                {
-                    "default_value": {
-                        "literal": {
-                            "value": {
-                                "name": "Two",
-                                "src": "b"
-                            },
-                            "type": "enum"
-                        }
-                    },
-                    "xref": [
-                        {
-                            "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
-                            "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 14}"
-                        }
-                    ],
-                    "name": "f",
-                    "requiredness": "default",
-                    "id": 6,
-                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 15, locStartCol = 15, locEndLine = 15, locEndCol = 16}",
-                    "type": {
-                        "name": {
-                            "name": "Number",
-                            "src": "b"
-                        },
-                        "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
-                        "type": "enum"
-                    }
-                },
-                {
-                    "xref": [],
-                    "name": "g",
-                    "requiredness": "optional",
-                    "id": 7,
-                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 16, locStartCol = 22, locEndLine = 16, locEndCol = 23}",
-                    "type": {
-                        "type": "string"
-                    }
-                },
-                {
-                    "xref": [],
-                    "name": "h",
-                    "requiredness": "required",
-                    "id": 8,
-                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 17, locStartCol = 22, locEndLine = 17, locEndCol = 23}",
-                    "type": {
-                        "type": "string"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "X",
-            "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 26, locStartCol = 11, locEndLine = 26, locEndCol = 12}",
-            "struct_type": "EXCEPTION",
-            "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 26, locStartCol = 1, locEndLine = 26, locEndCol = 10}",
-            "fields": [
-                {
-                    "xref": [],
-                    "name": "reason",
-                    "requiredness": "default",
-                    "id": 1,
-                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 27, locStartCol = 13, locEndLine = 27, locEndCol = 19}",
-                    "type": {
-                        "type": "string"
-                    }
-                }
-            ]
-        }
-    ],
-    "path": "test/if/a.thrift",
-    "unions": [
-        {
-            "name": "U",
-            "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 20, locStartCol = 7, locEndLine = 20, locEndCol = 8}",
-            "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 20, locStartCol = 1, locEndLine = 20, locEndCol = 6}",
-            "fields": [
-                {
-                    "name": "x",
-                    "id": 1,
-                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 21, locStartCol = 11, locEndLine = 21, locEndCol = 12}",
-                    "type": {
-                        "type": "byte"
-                    }
-                },
-                {
-                    "name": "y",
-                    "id": 2,
-                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 22, locStartCol = 19, locEndLine = 22, locEndCol = 20}",
-                    "type": {
-                        "inner_type": {
-                            "type": "string"
-                        },
-                        "type": "list"
-                    }
-                },
-                {
-                    "name": "z",
-                    "id": 3,
-                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 23, locStartCol = 15, locEndLine = 23, locEndCol = 16}",
-                    "type": {
-                        "inner_type": {
-                            "type": "i64"
-                        },
-                        "type": "set"
-                    }
-                }
-            ]
-        }
-    ],
     "consts": [
         {
-            "value": {
-                "named_constant": {
-                    "name": "i64_value",
-                    "src": "b"
-                }
-            },
             "ann_type": {
                 "anns": null,
                 "loc": [
@@ -255,33 +10,59 @@
                     "name": "T"
                 }
             },
-            "xref": [
-                {
-                    "rLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 13, locEndLine = 7, locEndCol = 14}",
-                    "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 30, locStartCol = 7, locEndLine = 30, locEndCol = 8}"
-                },
-                {
-                    "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 40, locStartCol = 11, locEndLine = 40, locEndCol = 20}",
-                    "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 30, locStartCol = 13, locEndLine = 30, locEndCol = 24}"
-                }
-            ],
-            "name": "a",
+            "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 30, locStartCol = 1, locEndLine = 30, locEndCol = 6}",
             "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 30, locStartCol = 9, locEndLine = 30, locEndCol = 10}",
+            "name": "a",
             "type": {
                 "inner_type": {
                     "type": "i64"
                 },
+                "loc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 13, locEndLine = 7, locEndCol = 14}",
                 "name": {
                     "name": "T"
                 },
-                "loc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 13, locEndLine = 7, locEndCol = 14}",
                 "type": "typedef"
             },
-            "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 30, locStartCol = 1, locEndLine = 30, locEndCol = 6}"
+            "value": {
+                "named_constant": {
+                    "name": "i64_value",
+                    "src": "b"
+                }
+            },
+            "xref": [
+                {
+                    "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 30, locStartCol = 7, locEndLine = 30, locEndCol = 8}",
+                    "rLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 13, locEndLine = 7, locEndCol = 14}"
+                },
+                {
+                    "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 30, locStartCol = 13, locEndLine = 30, locEndCol = 24}",
+                    "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 40, locStartCol = 11, locEndLine = 40, locEndCol = 20}"
+                }
+            ]
         },
         {
+            "ann_type": {
+                "anns": null,
+                "loc": [
+                    "Loc {locFile = \"test/if/a.thrift\", locStartLine = 32, locStartCol = 7, locEndLine = 32, locEndCol = 8}"
+                ],
+                "type": {
+                    "name": "U"
+                }
+            },
+            "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 32, locStartCol = 1, locEndLine = 32, locEndCol = 6}",
+            "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 32, locStartCol = 9, locEndLine = 32, locEndCol = 10}",
+            "name": "u",
+            "type": {
+                "loc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 20, locStartCol = 7, locEndLine = 20, locEndCol = 8}",
+                "name": {
+                    "name": "U"
+                },
+                "type": "union"
+            },
             "value": {
                 "literal": {
+                    "type": "union",
                     "value": {
                         "field_name": "y",
                         "field_type": {
@@ -292,6 +73,7 @@
                         },
                         "field_value": {
                             "literal": {
+                                "type": "list",
                                 "value": [
                                     {
                                         "named_constant": {
@@ -299,43 +81,43 @@
                                             "src": "b"
                                         }
                                     }
-                                ],
-                                "type": "list"
+                                ]
                             }
                         }
-                    },
-                    "type": "union"
-                }
-            },
-            "ann_type": {
-                "anns": null,
-                "loc": [
-                    "Loc {locFile = \"test/if/a.thrift\", locStartLine = 32, locStartCol = 7, locEndLine = 32, locEndCol = 8}"
-                ],
-                "type": {
-                    "name": "U"
+                    }
                 }
             },
             "xref": [
                 {
-                    "rLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 20, locStartCol = 7, locEndLine = 20, locEndCol = 8}",
-                    "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 32, locStartCol = 7, locEndLine = 32, locEndCol = 8}"
+                    "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 32, locStartCol = 7, locEndLine = 32, locEndCol = 8}",
+                    "rLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 20, locStartCol = 7, locEndLine = 20, locEndCol = 8}"
                 }
-            ],
-            "name": "u",
-            "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 32, locStartCol = 9, locEndLine = 32, locEndCol = 10}",
-            "type": {
-                "name": {
-                    "name": "U"
-                },
-                "loc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 20, locStartCol = 7, locEndLine = 20, locEndCol = 8}",
-                "type": "union"
-            },
-            "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 32, locStartCol = 1, locEndLine = 32, locEndCol = 6}"
+            ]
         },
         {
+            "ann_type": {
+                "anns": null,
+                "loc": [
+                    "Loc {locFile = \"test/if/a.thrift\", locStartLine = 34, locStartCol = 7, locEndLine = 34, locEndCol = 10}"
+                ],
+                "type": {
+                    "name": "b.B"
+                }
+            },
+            "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 34, locStartCol = 1, locEndLine = 34, locEndCol = 6}",
+            "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 34, locStartCol = 11, locEndLine = 34, locEndCol = 12}",
+            "name": "b",
+            "type": {
+                "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
+                "name": {
+                    "name": "B",
+                    "src": "b"
+                },
+                "type": "struct"
+            },
             "value": {
                 "literal": {
+                    "type": "struct",
                     "value": [
                         {
                             "field_name": "a",
@@ -373,40 +155,40 @@
                                 }
                             }
                         }
-                    ],
-                    "type": "struct"
+                    ]
                 }
             },
+            "xref": [
+                {
+                    "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 34, locStartCol = 7, locEndLine = 34, locEndCol = 10}",
+                    "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}"
+                }
+            ]
+        },
+        {
             "ann_type": {
                 "anns": null,
                 "loc": [
-                    "Loc {locFile = \"test/if/a.thrift\", locStartLine = 34, locStartCol = 7, locEndLine = 34, locEndCol = 10}"
+                    "Loc {locFile = \"test/if/a.thrift\", locStartLine = 40, locStartCol = 7, locEndLine = 40, locEndCol = 10}"
                 ],
                 "type": {
                     "name": "b.B"
                 }
             },
-            "xref": [
-                {
-                    "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
-                    "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 34, locStartCol = 7, locEndLine = 34, locEndCol = 10}"
-                }
-            ],
-            "name": "b",
-            "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 34, locStartCol = 11, locEndLine = 34, locEndCol = 12}",
+            "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 40, locStartCol = 1, locEndLine = 40, locEndCol = 6}",
+            "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 40, locStartCol = 11, locEndLine = 40, locEndCol = 20}",
+            "name": "default_d",
             "type": {
+                "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
                 "name": {
                     "name": "B",
                     "src": "b"
                 },
-                "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
                 "type": "struct"
             },
-            "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 34, locStartCol = 1, locEndLine = 34, locEndCol = 6}"
-        },
-        {
             "value": {
                 "literal": {
+                    "type": "struct",
                     "value": [
                         {
                             "field_name": "a",
@@ -435,47 +217,17 @@
                                 "default": null
                             }
                         }
-                    ],
-                    "type": "struct"
-                }
-            },
-            "ann_type": {
-                "anns": null,
-                "loc": [
-                    "Loc {locFile = \"test/if/a.thrift\", locStartLine = 40, locStartCol = 7, locEndLine = 40, locEndCol = 10}"
-                ],
-                "type": {
-                    "name": "b.B"
+                    ]
                 }
             },
             "xref": [
                 {
-                    "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
-                    "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 40, locStartCol = 7, locEndLine = 40, locEndCol = 10}"
+                    "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 40, locStartCol = 7, locEndLine = 40, locEndCol = 10}",
+                    "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}"
                 }
-            ],
-            "name": "default_d",
-            "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 40, locStartCol = 11, locEndLine = 40, locEndCol = 20}",
-            "type": {
-                "name": {
-                    "name": "B",
-                    "src": "b"
-                },
-                "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
-                "type": "struct"
-            },
-            "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 40, locStartCol = 1, locEndLine = 40, locEndCol = 6}"
+            ]
         },
         {
-            "value": {
-                "literal": {
-                    "value": {
-                        "name": "Zero",
-                        "src": "b"
-                    },
-                    "type": "enum"
-                }
-            },
             "ann_type": {
                 "anns": null,
                 "loc": [
@@ -485,128 +237,376 @@
                     "name": "b.Number"
                 }
             },
-            "xref": [
-                {
-                    "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
-                    "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 42, locStartCol = 7, locEndLine = 42, locEndCol = 15}"
-                },
-                {
-                    "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 16, locStartCol = 3, locEndLine = 16, locEndCol = 7}",
-                    "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 42, locStartCol = 23, locEndLine = 42, locEndCol = 29}"
-                }
-            ],
-            "name": "zero",
+            "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 42, locStartCol = 1, locEndLine = 42, locEndCol = 6}",
             "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 42, locStartCol = 16, locEndLine = 42, locEndCol = 20}",
+            "name": "zero",
             "type": {
+                "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
                 "name": {
                     "name": "Number",
                     "src": "b"
                 },
-                "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
                 "type": "enum"
             },
-            "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 42, locStartCol = 1, locEndLine = 42, locEndCol = 6}"
+            "value": {
+                "literal": {
+                    "type": "enum",
+                    "value": {
+                        "name": "Zero",
+                        "src": "b"
+                    }
+                }
+            },
+            "xref": [
+                {
+                    "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 42, locStartCol = 7, locEndLine = 42, locEndCol = 15}",
+                    "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}"
+                },
+                {
+                    "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 42, locStartCol = 23, locEndLine = 42, locEndCol = 29}",
+                    "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 16, locStartCol = 3, locEndLine = 16, locEndCol = 7}"
+                }
+            ]
         }
     ],
-    "name": "a",
+    "enums": [],
     "includes": [
         "test/if/b.thrift"
     ],
-    "enums": [],
+    "name": "a",
     "options": {
-        "path": "test/if/a.thrift",
-        "include_path": ".",
         "genfiles": null,
+        "include_path": ".",
         "out_path": "test/fixtures/gen-basic-loc",
+        "path": "test/if/a.thrift",
         "recursive": true
     },
+    "path": "test/if/a.thrift",
     "services": [
         {
-            "name": "S",
-            "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 44, locStartCol = 9, locEndLine = 44, locEndCol = 10}",
-            "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 44, locStartCol = 1, locEndLine = 44, locEndCol = 8}",
             "functions": [
                 {
                     "args": [
                         {
-                            "xref": [],
-                            "name": "x",
                             "id": 1,
                             "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 46, locStartCol = 29, locEndLine = 46, locEndCol = 30}",
+                            "name": "x",
                             "type": {
                                 "type": "i32"
-                            }
+                            },
+                            "xref": []
                         }
                     ],
+                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 46, locStartCol = 12, locEndLine = 46, locEndCol = 21}",
+                    "name": "getNumber",
+                    "oneway": false,
                     "return_type": {
+                        "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
                         "name": {
                             "name": "Number",
                             "src": "b"
                         },
-                        "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
                         "type": "enum"
                     },
-                    "throws": [],
-                    "name": "getNumber",
-                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 46, locStartCol = 12, locEndLine = 46, locEndCol = 21}",
-                    "oneway": false
+                    "throws": []
                 },
                 {
                     "args": [],
+                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 48, locStartCol = 8, locEndLine = 48, locEndCol = 17}",
+                    "name": "doNothing",
+                    "oneway": false,
                     "return_type": {
                         "type": "void"
                     },
                     "throws": [
                         {
-                            "xref": [
-                                {
-                                    "rLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 26, locStartCol = 11, locEndLine = 26, locEndCol = 12}",
-                                    "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 48, locStartCol = 31, locEndLine = 48, locEndCol = 32}"
-                                }
-                            ],
-                            "name": "ex",
                             "id": 1,
                             "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 48, locStartCol = 33, locEndLine = 48, locEndCol = 35}",
+                            "name": "ex",
                             "type": {
+                                "loc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 26, locStartCol = 11, locEndLine = 26, locEndCol = 12}",
                                 "name": {
                                     "name": "X"
                                 },
-                                "loc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 26, locStartCol = 11, locEndLine = 26, locEndCol = 12}",
                                 "type": "exception"
-                            }
+                            },
+                            "xref": [
+                                {
+                                    "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 48, locStartCol = 31, locEndLine = 48, locEndCol = 32}",
+                                    "rLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 26, locStartCol = 11, locEndLine = 26, locEndCol = 12}"
+                                }
+                            ]
                         }
-                    ],
-                    "name": "doNothing",
-                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 48, locStartCol = 8, locEndLine = 48, locEndCol = 17}",
-                    "oneway": false
+                    ]
                 }
-            ]
+            ],
+            "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 44, locStartCol = 1, locEndLine = 44, locEndCol = 8}",
+            "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 44, locStartCol = 9, locEndLine = 44, locEndCol = 10}",
+            "name": "S"
         },
         {
-            "name": "ParentService",
-            "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 52, locStartCol = 9, locEndLine = 52, locEndCol = 22}",
+            "functions": [],
             "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 52, locStartCol = 1, locEndLine = 52, locEndCol = 8}",
-            "functions": []
+            "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 52, locStartCol = 9, locEndLine = 52, locEndCol = 22}",
+            "name": "ParentService"
         },
         {
-            "super": {
-                "name": "ParentService"
-            },
-            "name": "ChildService",
-            "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 55, locStartCol = 9, locEndLine = 55, locEndCol = 21}",
-            "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 55, locStartCol = 1, locEndLine = 55, locEndCol = 8}",
             "functions": [
                 {
                     "args": [],
+                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 56, locStartCol = 7, locEndLine = 56, locEndCol = 10}",
+                    "name": "foo",
+                    "oneway": false,
                     "return_type": {
                         "type": "i32"
                     },
-                    "throws": [],
-                    "name": "foo",
-                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 56, locStartCol = 7, locEndLine = 56, locEndCol = 10}",
-                    "oneway": false
+                    "throws": []
                 }
-            ]
+            ],
+            "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 55, locStartCol = 1, locEndLine = 55, locEndCol = 8}",
+            "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 55, locStartCol = 9, locEndLine = 55, locEndCol = 21}",
+            "name": "ChildService",
+            "super": {
+                "name": "ParentService"
+            }
+        }
+    ],
+    "structs": [
+        {
+            "fields": [
+                {
+                    "default_value": {
+                        "named_constant": {
+                            "name": "a"
+                        }
+                    },
+                    "id": 1,
+                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 10, locStartCol = 8, locEndLine = 10, locEndCol = 9}",
+                    "name": "a",
+                    "requiredness": "default",
+                    "type": {
+                        "inner_type": {
+                            "type": "i64"
+                        },
+                        "loc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 13, locEndLine = 7, locEndCol = 14}",
+                        "name": {
+                            "name": "T"
+                        },
+                        "type": "typedef"
+                    },
+                    "xref": [
+                        {
+                            "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 10, locStartCol = 6, locEndLine = 10, locEndCol = 7}",
+                            "rLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 13, locEndLine = 7, locEndCol = 14}"
+                        }
+                    ]
+                },
+                {
+                    "default_value": {
+                        "named_constant": {
+                            "name": "b"
+                        }
+                    },
+                    "id": 2,
+                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 11, locStartCol = 10, locEndLine = 11, locEndCol = 11}",
+                    "name": "b",
+                    "requiredness": "default",
+                    "type": {
+                        "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
+                        "name": {
+                            "name": "B",
+                            "src": "b"
+                        },
+                        "type": "struct"
+                    },
+                    "xref": [
+                        {
+                            "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 11, locStartCol = 6, locEndLine = 11, locEndCol = 9}",
+                            "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}"
+                        }
+                    ]
+                },
+                {
+                    "default_value": {
+                        "named_constant": {
+                            "name": "bool_value",
+                            "src": "b"
+                        }
+                    },
+                    "id": 3,
+                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 12, locStartCol = 11, locEndLine = 12, locEndCol = 12}",
+                    "name": "c",
+                    "requiredness": "default",
+                    "type": {
+                        "type": "bool"
+                    },
+                    "xref": []
+                },
+                {
+                    "id": 4,
+                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 13, locStartCol = 22, locEndLine = 13, locEndCol = 23}",
+                    "name": "d",
+                    "requiredness": "default",
+                    "type": {
+                        "inner_type": {
+                            "inner_type": {
+                                "type": "i32"
+                            },
+                            "type": "list"
+                        },
+                        "type": "list"
+                    },
+                    "xref": []
+                },
+                {
+                    "id": 5,
+                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 14, locStartCol = 23, locEndLine = 14, locEndCol = 24}",
+                    "name": "e",
+                    "requiredness": "default",
+                    "type": {
+                        "key_type": {
+                            "type": "i32"
+                        },
+                        "type": "map",
+                        "val_type": {
+                            "type": "string"
+                        }
+                    },
+                    "xref": []
+                },
+                {
+                    "default_value": {
+                        "literal": {
+                            "type": "enum",
+                            "value": {
+                                "name": "Two",
+                                "src": "b"
+                            }
+                        }
+                    },
+                    "id": 6,
+                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 15, locStartCol = 15, locEndLine = 15, locEndCol = 16}",
+                    "name": "f",
+                    "requiredness": "default",
+                    "type": {
+                        "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
+                        "name": {
+                            "name": "Number",
+                            "src": "b"
+                        },
+                        "type": "enum"
+                    },
+                    "xref": [
+                        {
+                            "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 14}",
+                            "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}"
+                        }
+                    ]
+                },
+                {
+                    "id": 7,
+                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 16, locStartCol = 22, locEndLine = 16, locEndCol = 23}",
+                    "name": "g",
+                    "requiredness": "optional",
+                    "type": {
+                        "type": "string"
+                    },
+                    "xref": []
+                },
+                {
+                    "id": 8,
+                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 17, locStartCol = 22, locEndLine = 17, locEndCol = 23}",
+                    "name": "h",
+                    "requiredness": "required",
+                    "type": {
+                        "type": "string"
+                    },
+                    "xref": []
+                }
+            ],
+            "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 9, locStartCol = 1, locEndLine = 9, locEndCol = 7}",
+            "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 9, locStartCol = 8, locEndLine = 9, locEndCol = 9}",
+            "name": "A",
+            "struct_type": "STRUCT"
+        },
+        {
+            "fields": [
+                {
+                    "id": 1,
+                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 27, locStartCol = 13, locEndLine = 27, locEndCol = 19}",
+                    "name": "reason",
+                    "requiredness": "default",
+                    "type": {
+                        "type": "string"
+                    },
+                    "xref": []
+                }
+            ],
+            "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 26, locStartCol = 1, locEndLine = 26, locEndCol = 10}",
+            "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 26, locStartCol = 11, locEndLine = 26, locEndCol = 12}",
+            "name": "X",
+            "struct_type": "EXCEPTION"
+        }
+    ],
+    "typedefs": [
+        {
+            "ann_type": {
+                "anns": null,
+                "loc": [
+                    "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 9, locEndLine = 7, locEndCol = 12}"
+                ],
+                "type": {
+                    "type": "i64"
+                }
+            },
+            "anns": null,
+            "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 1, locEndLine = 7, locEndCol = 8}",
+            "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 13, locEndLine = 7, locEndCol = 14}",
+            "name": "T",
+            "newtype": false,
+            "type": {
+                "type": "i64"
+            },
+            "xref": []
+        }
+    ],
+    "unions": [
+        {
+            "fields": [
+                {
+                    "id": 1,
+                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 21, locStartCol = 11, locEndLine = 21, locEndCol = 12}",
+                    "name": "x",
+                    "type": {
+                        "type": "byte"
+                    }
+                },
+                {
+                    "id": 2,
+                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 22, locStartCol = 19, locEndLine = 22, locEndCol = 20}",
+                    "name": "y",
+                    "type": {
+                        "inner_type": {
+                            "type": "string"
+                        },
+                        "type": "list"
+                    }
+                },
+                {
+                    "id": 3,
+                    "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 23, locStartCol = 15, locEndLine = 23, locEndCol = 16}",
+                    "name": "z",
+                    "type": {
+                        "inner_type": {
+                            "type": "i64"
+                        },
+                        "type": "set"
+                    }
+                }
+            ],
+            "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 20, locStartCol = 1, locEndLine = 20, locEndCol = 6}",
+            "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 20, locStartCol = 7, locEndLine = 20, locEndCol = 8}",
+            "name": "U"
         }
     ]
 }

--- a/compiler/test/fixtures/gen-basic-loc/b.ast
+++ b/compiler/test/fixtures/gen-basic-loc/b.ast
@@ -1,166 +1,6 @@
 {
-    "typedefs": [
-        {
-            "newtype": true,
-            "anns": {
-                "loc_ann_list": [
-                    {
-                        "ann_tag": "hs.newtype",
-                        "ann_type": "SimpleAnn",
-                        "sep": {
-                            "sep_type": "NoSep"
-                        },
-                        "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 18, locEndLine = 34, locEndCol = 28}"
-                    }
-                ],
-                "loc_close": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 28, locEndLine = 34, locEndCol = 29}",
-                "loc_open": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 17, locEndLine = 34, locEndCol = 18}"
-            },
-            "ann_type": {
-                "anns": null,
-                "loc": [
-                    "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 9, locEndLine = 34, locEndCol = 12}"
-                ],
-                "type": {
-                    "type": "i64"
-                }
-            },
-            "xref": [],
-            "name": "Int",
-            "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 13, locEndLine = 34, locEndCol = 16}",
-            "type": {
-                "type": "i64"
-            },
-            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 1, locEndLine = 34, locEndCol = 8}"
-        }
-    ],
-    "structs": [
-        {
-            "name": "B",
-            "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
-            "struct_type": "STRUCT",
-            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 1, locEndLine = 3, locEndCol = 7}",
-            "fields": [
-                {
-                    "default_value": {
-                        "literal": {
-                            "value": 1,
-                            "type": "i16"
-                        }
-                    },
-                    "xref": [],
-                    "name": "a",
-                    "requiredness": "default",
-                    "id": 1,
-                    "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 4, locStartCol = 10, locEndLine = 4, locEndCol = 11}",
-                    "type": {
-                        "type": "i16"
-                    }
-                },
-                {
-                    "xref": [],
-                    "name": "b",
-                    "requiredness": "default",
-                    "id": 2,
-                    "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 5, locStartCol = 10, locEndLine = 5, locEndCol = 11}",
-                    "type": {
-                        "type": "i32"
-                    }
-                },
-                {
-                    "xref": [],
-                    "name": "c",
-                    "requiredness": "default",
-                    "id": 3,
-                    "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 6, locStartCol = 10, locEndLine = 6, locEndCol = 11}",
-                    "type": {
-                        "type": "i64"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "C",
-            "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 9, locStartCol = 8, locEndLine = 9, locEndCol = 9}",
-            "struct_type": "STRUCT",
-            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 9, locStartCol = 1, locEndLine = 9, locEndCol = 7}",
-            "fields": [
-                {
-                    "xref": [
-                        {
-                            "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
-                            "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 10, locStartCol = 11, locEndLine = 10, locEndCol = 17}"
-                        }
-                    ],
-                    "name": "x",
-                    "requiredness": "default",
-                    "id": 1,
-                    "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 10, locStartCol = 19, locEndLine = 10, locEndCol = 20}",
-                    "type": {
-                        "inner_type": {
-                            "name": {
-                                "name": "Number"
-                            },
-                            "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
-                            "type": "enum"
-                        },
-                        "type": "list"
-                    }
-                },
-                {
-                    "xref": [
-                        {
-                            "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 22, locStartCol = 6, locEndLine = 22, locEndCol = 19}",
-                            "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 11, locStartCol = 11, locEndLine = 11, locEndCol = 24}"
-                        }
-                    ],
-                    "name": "y",
-                    "requiredness": "default",
-                    "id": 2,
-                    "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 11, locStartCol = 26, locEndLine = 11, locEndCol = 27}",
-                    "type": {
-                        "inner_type": {
-                            "name": {
-                                "name": "Number_Strict"
-                            },
-                            "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 22, locStartCol = 6, locEndLine = 22, locEndCol = 19}",
-                            "type": "enum"
-                        },
-                        "type": "list"
-                    }
-                },
-                {
-                    "xref": [
-                        {
-                            "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
-                            "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 12, locStartCol = 6, locEndLine = 12, locEndCol = 7}"
-                        }
-                    ],
-                    "name": "z",
-                    "requiredness": "default",
-                    "id": 3,
-                    "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 12, locStartCol = 8, locEndLine = 12, locEndCol = 9}",
-                    "type": {
-                        "name": {
-                            "name": "B"
-                        },
-                        "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
-                        "type": "struct"
-                    }
-                }
-            ]
-        }
-    ],
-    "path": "test/if/b.thrift",
-    "unions": [],
     "consts": [
         {
-            "value": {
-                "literal": {
-                    "value": 0,
-                    "type": "byte"
-                }
-            },
             "ann_type": {
                 "anns": null,
                 "loc": [
@@ -170,21 +10,21 @@
                     "type": "byte"
                 }
             },
-            "xref": [],
-            "name": "byte_value",
+            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 37, locStartCol = 1, locEndLine = 37, locEndCol = 6}",
             "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 37, locStartCol = 12, locEndLine = 37, locEndCol = 22}",
+            "name": "byte_value",
             "type": {
                 "type": "byte"
             },
-            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 37, locStartCol = 1, locEndLine = 37, locEndCol = 6}"
-        },
-        {
             "value": {
                 "literal": {
-                    "value": 1,
-                    "type": "i16"
+                    "type": "byte",
+                    "value": 0
                 }
             },
+            "xref": []
+        },
+        {
             "ann_type": {
                 "anns": null,
                 "loc": [
@@ -194,21 +34,21 @@
                     "type": "i16"
                 }
             },
-            "xref": [],
-            "name": "i16_value",
+            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 38, locStartCol = 1, locEndLine = 38, locEndCol = 6}",
             "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 38, locStartCol = 11, locEndLine = 38, locEndCol = 20}",
+            "name": "i16_value",
             "type": {
                 "type": "i16"
             },
-            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 38, locStartCol = 1, locEndLine = 38, locEndCol = 6}"
-        },
-        {
             "value": {
                 "literal": {
-                    "value": 2,
-                    "type": "i32"
+                    "type": "i16",
+                    "value": 1
                 }
             },
+            "xref": []
+        },
+        {
             "ann_type": {
                 "anns": null,
                 "loc": [
@@ -218,22 +58,21 @@
                     "type": "i32"
                 }
             },
-            "xref": [],
-            "name": "i32_value",
+            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 39, locStartCol = 1, locEndLine = 39, locEndCol = 6}",
             "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 39, locStartCol = 11, locEndLine = 39, locEndCol = 20}",
+            "name": "i32_value",
             "type": {
                 "type": "i32"
             },
-            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 39, locStartCol = 1, locEndLine = 39, locEndCol = 6}"
-        },
-        {
             "value": {
                 "literal": {
-                    "string": "3",
-                    "value": 3,
-                    "type": "i64"
+                    "type": "i32",
+                    "value": 2
                 }
             },
+            "xref": []
+        },
+        {
             "ann_type": {
                 "anns": null,
                 "loc": [
@@ -243,22 +82,22 @@
                     "type": "i64"
                 }
             },
-            "xref": [],
-            "name": "i64_value",
+            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 40, locStartCol = 1, locEndLine = 40, locEndCol = 6}",
             "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 40, locStartCol = 11, locEndLine = 40, locEndCol = 20}",
+            "name": "i64_value",
             "type": {
                 "type": "i64"
             },
-            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 40, locStartCol = 1, locEndLine = 40, locEndCol = 6}"
-        },
-        {
             "value": {
                 "literal": {
-                    "value": 0.5,
-                    "binary": "3f000000",
-                    "type": "float"
+                    "string": "3",
+                    "type": "i64",
+                    "value": 3
                 }
             },
+            "xref": []
+        },
+        {
             "ann_type": {
                 "anns": null,
                 "loc": [
@@ -268,22 +107,22 @@
                     "type": "float"
                 }
             },
-            "xref": [],
-            "name": "float_value",
+            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 41, locStartCol = 1, locEndLine = 41, locEndCol = 6}",
             "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 41, locStartCol = 13, locEndLine = 41, locEndCol = 24}",
+            "name": "float_value",
             "type": {
                 "type": "float"
             },
-            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 41, locStartCol = 1, locEndLine = 41, locEndCol = 6}"
-        },
-        {
             "value": {
                 "literal": {
-                    "value": 3.14159,
-                    "binary": "400921f9f01b866e",
-                    "type": "double"
+                    "binary": "3f000000",
+                    "type": "float",
+                    "value": 0.5
                 }
             },
+            "xref": []
+        },
+        {
             "ann_type": {
                 "anns": null,
                 "loc": [
@@ -293,21 +132,22 @@
                     "type": "double"
                 }
             },
-            "xref": [],
-            "name": "double_value",
+            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 42, locStartCol = 1, locEndLine = 42, locEndCol = 6}",
             "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 42, locStartCol = 14, locEndLine = 42, locEndCol = 26}",
+            "name": "double_value",
             "type": {
                 "type": "double"
             },
-            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 42, locStartCol = 1, locEndLine = 42, locEndCol = 6}"
-        },
-        {
             "value": {
                 "literal": {
-                    "value": true,
-                    "type": "bool"
+                    "binary": "400921f9f01b866e",
+                    "type": "double",
+                    "value": 3.14159
                 }
             },
+            "xref": []
+        },
+        {
             "ann_type": {
                 "anns": null,
                 "loc": [
@@ -317,21 +157,21 @@
                     "type": "bool"
                 }
             },
-            "xref": [],
-            "name": "bool_value",
+            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 43, locStartCol = 1, locEndLine = 43, locEndCol = 6}",
             "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 43, locStartCol = 12, locEndLine = 43, locEndCol = 22}",
+            "name": "bool_value",
             "type": {
                 "type": "bool"
             },
-            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 43, locStartCol = 1, locEndLine = 43, locEndCol = 6}"
-        },
-        {
             "value": {
                 "literal": {
-                    "value": "xxx",
-                    "type": "string"
+                    "type": "bool",
+                    "value": true
                 }
             },
+            "xref": []
+        },
+        {
             "ann_type": {
                 "anns": null,
                 "loc": [
@@ -341,21 +181,21 @@
                     "type": "string"
                 }
             },
-            "xref": [],
-            "name": "string_value",
+            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 44, locStartCol = 1, locEndLine = 44, locEndCol = 6}",
             "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 44, locStartCol = 14, locEndLine = 44, locEndCol = 26}",
+            "name": "string_value",
             "type": {
                 "type": "string"
             },
-            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 44, locStartCol = 1, locEndLine = 44, locEndCol = 6}"
-        },
-        {
             "value": {
                 "literal": {
-                    "value": "797979",
-                    "type": "binary"
+                    "type": "string",
+                    "value": "xxx"
                 }
             },
+            "xref": []
+        },
+        {
             "ann_type": {
                 "anns": null,
                 "loc": [
@@ -365,25 +205,21 @@
                     "type": "binary"
                 }
             },
-            "xref": [],
-            "name": "binary_value",
+            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 45, locStartCol = 1, locEndLine = 45, locEndCol = 6}",
             "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 45, locStartCol = 14, locEndLine = 45, locEndCol = 26}",
+            "name": "binary_value",
             "type": {
                 "type": "binary"
             },
-            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 45, locStartCol = 1, locEndLine = 45, locEndCol = 6}"
-        },
-        {
             "value": {
                 "literal": {
-                    "value": {
-                        "string": "10",
-                        "value": 10,
-                        "type": "i64"
-                    },
-                    "type": "newtype"
+                    "type": "binary",
+                    "value": "797979"
                 }
             },
+            "xref": []
+        },
+        {
             "ann_type": {
                 "anns": null,
                 "loc": [
@@ -393,46 +229,37 @@
                     "name": "Int"
                 }
             },
-            "xref": [
-                {
-                    "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 13, locEndLine = 34, locEndCol = 16}",
-                    "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 46, locStartCol = 7, locEndLine = 46, locEndCol = 10}"
-                }
-            ],
-            "name": "newtype_value",
+            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 46, locStartCol = 1, locEndLine = 46, locEndCol = 6}",
             "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 46, locStartCol = 11, locEndLine = 46, locEndCol = 24}",
+            "name": "newtype_value",
             "type": {
                 "inner_type": {
                     "type": "i64"
                 },
+                "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 13, locEndLine = 34, locEndCol = 16}",
                 "name": {
                     "name": "Int"
                 },
-                "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 13, locEndLine = 34, locEndCol = 16}",
                 "type": "newtype"
             },
-            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 46, locStartCol = 1, locEndLine = 46, locEndCol = 6}"
-        },
-        {
             "value": {
                 "literal": {
-                    "value": [
-                        {
-                            "literal": {
-                                "string": "0",
-                                "value": 0,
-                                "type": "i64"
-                            }
-                        },
-                        {
-                            "named_constant": {
-                                "name": "i64_value"
-                            }
-                        }
-                    ],
-                    "type": "list"
+                    "type": "newtype",
+                    "value": {
+                        "string": "10",
+                        "type": "i64",
+                        "value": 10
+                    }
                 }
             },
+            "xref": [
+                {
+                    "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 46, locStartCol = 7, locEndLine = 46, locEndCol = 10}",
+                    "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 13, locEndLine = 34, locEndCol = 16}"
+                }
+            ]
+        },
+        {
             "ann_type": {
                 "anns": null,
                 "loc": [
@@ -453,36 +280,37 @@
                     "type": "list"
                 }
             },
-            "xref": [],
-            "name": "list_value",
+            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 49, locStartCol = 1, locEndLine = 49, locEndCol = 6}",
             "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 49, locStartCol = 17, locEndLine = 49, locEndCol = 27}",
+            "name": "list_value",
             "type": {
                 "inner_type": {
                     "type": "i64"
                 },
                 "type": "list"
             },
-            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 49, locStartCol = 1, locEndLine = 49, locEndCol = 6}"
-        },
-        {
             "value": {
                 "literal": {
+                    "type": "list",
                     "value": [
                         {
-                            "named_constant": {
-                                "name": "string_value"
+                            "literal": {
+                                "string": "0",
+                                "type": "i64",
+                                "value": 0
                             }
                         },
                         {
-                            "literal": {
-                                "value": "",
-                                "type": "string"
+                            "named_constant": {
+                                "name": "i64_value"
                             }
                         }
-                    ],
-                    "type": "set"
+                    ]
                 }
             },
+            "xref": []
+        },
+        {
             "ann_type": {
                 "anns": null,
                 "loc": [
@@ -503,55 +331,36 @@
                     "type": "set"
                 }
             },
-            "xref": [],
-            "name": "set_value",
+            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 50, locStartCol = 1, locEndLine = 50, locEndCol = 6}",
             "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 50, locStartCol = 19, locEndLine = 50, locEndCol = 28}",
+            "name": "set_value",
             "type": {
                 "inner_type": {
                     "type": "string"
                 },
                 "type": "set"
             },
-            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 50, locStartCol = 1, locEndLine = 50, locEndCol = 6}"
-        },
-        {
             "value": {
                 "literal": {
+                    "type": "set",
                     "value": [
                         {
-                            "key": {
-                                "literal": {
-                                    "string": "0",
-                                    "value": 0,
-                                    "type": "i64"
-                                }
-                            },
-                            "val": {
-                                "literal": {
-                                    "value": true,
-                                    "type": "bool"
-                                }
+                            "named_constant": {
+                                "name": "string_value"
                             }
                         },
                         {
-                            "key": {
-                                "literal": {
-                                    "string": "1",
-                                    "value": 1,
-                                    "type": "i64"
-                                }
-                            },
-                            "val": {
-                                "literal": {
-                                    "value": false,
-                                    "type": "bool"
-                                }
+                            "literal": {
+                                "type": "string",
+                                "value": ""
                             }
                         }
-                    ],
-                    "type": "map"
+                    ]
                 }
             },
+            "xref": []
+        },
+        {
             "ann_type": {
                 "anns": null,
                 "loc": [
@@ -561,15 +370,6 @@
                     "Loc {locFile = \"test/if/b.thrift\", locStartLine = 53, locStartCol = 20, locEndLine = 53, locEndCol = 21}"
                 ],
                 "type": {
-                    "val_type": {
-                        "anns": null,
-                        "loc": [
-                            "Loc {locFile = \"test/if/b.thrift\", locStartLine = 53, locStartCol = 16, locEndLine = 53, locEndCol = 20}"
-                        ],
-                        "type": {
-                            "type": "bool"
-                        }
-                    },
                     "key_type": {
                         "anns": null,
                         "loc": [
@@ -579,75 +379,86 @@
                             "type": "i64"
                         }
                     },
-                    "type": "map"
+                    "type": "map",
+                    "val_type": {
+                        "anns": null,
+                        "loc": [
+                            "Loc {locFile = \"test/if/b.thrift\", locStartLine = 53, locStartCol = 16, locEndLine = 53, locEndCol = 20}"
+                        ],
+                        "type": {
+                            "type": "bool"
+                        }
+                    }
                 }
             },
-            "xref": [],
-            "name": "map_value",
+            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 53, locStartCol = 1, locEndLine = 53, locEndCol = 6}",
             "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 53, locStartCol = 22, locEndLine = 53, locEndCol = 31}",
+            "name": "map_value",
             "type": {
-                "val_type": {
-                    "type": "bool"
-                },
                 "key_type": {
                     "type": "i64"
                 },
-                "type": "map"
+                "type": "map",
+                "val_type": {
+                    "type": "bool"
+                }
             },
-            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 53, locStartCol = 1, locEndLine = 53, locEndCol = 6}"
-        },
-        {
             "value": {
                 "literal": {
+                    "type": "map",
                     "value": [
                         {
                             "key": {
                                 "literal": {
-                                    "value": "a",
-                                    "type": "string"
+                                    "string": "0",
+                                    "type": "i64",
+                                    "value": 0
                                 }
                             },
                             "val": {
                                 "literal": {
-                                    "value": "A",
-                                    "type": "string"
+                                    "type": "bool",
+                                    "value": true
                                 }
                             }
                         },
                         {
                             "key": {
                                 "literal": {
-                                    "value": "b",
-                                    "type": "string"
+                                    "string": "1",
+                                    "type": "i64",
+                                    "value": 1
                                 }
                             },
                             "val": {
                                 "literal": {
-                                    "value": "B",
-                                    "type": "string"
+                                    "type": "bool",
+                                    "value": false
                                 }
                             }
                         }
-                    ],
-                    "type": "map"
+                    ]
                 }
             },
+            "xref": []
+        },
+        {
             "ann_type": {
                 "anns": {
                     "loc_ann_list": [
                         {
-                            "loc_val": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 54, locStartCol = 38, locEndLine = 54, locEndCol = 47}",
-                            "tag": "hs.type",
                             "ann_type": "ValueAnn",
+                            "loc_equal": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 54, locStartCol = 36, locEndLine = 54, locEndCol = 37}",
+                            "loc_tag": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 54, locStartCol = 28, locEndLine = 54, locEndCol = 35}",
+                            "loc_val": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 54, locStartCol = 38, locEndLine = 54, locEndCol = 47}",
                             "sep": {
                                 "sep_type": "NoSep"
                             },
-                            "loc_tag": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 54, locStartCol = 28, locEndLine = 54, locEndCol = 35}",
-                            "loc_equal": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 54, locStartCol = 36, locEndLine = 54, locEndCol = 37}",
+                            "tag": "hs.type",
                             "val": {
+                                "ann_value_type": "TextAnn",
                                 "q": "DoubleQuote",
-                                "t": "HashMap",
-                                "ann_value_type": "TextAnn"
+                                "t": "HashMap"
                             }
                         }
                     ],
@@ -661,15 +472,6 @@
                     "Loc {locFile = \"test/if/b.thrift\", locStartLine = 54, locStartCol = 25, locEndLine = 54, locEndCol = 26}"
                 ],
                 "type": {
-                    "val_type": {
-                        "anns": null,
-                        "loc": [
-                            "Loc {locFile = \"test/if/b.thrift\", locStartLine = 54, locStartCol = 19, locEndLine = 54, locEndCol = 25}"
-                        ],
-                        "type": {
-                            "type": "string"
-                        }
-                    },
                     "key_type": {
                         "anns": null,
                         "loc": [
@@ -679,68 +481,68 @@
                             "type": "string"
                         }
                     },
-                    "type": "map"
+                    "type": "map",
+                    "val_type": {
+                        "anns": null,
+                        "loc": [
+                            "Loc {locFile = \"test/if/b.thrift\", locStartLine = 54, locStartCol = 19, locEndLine = 54, locEndCol = 25}"
+                        ],
+                        "type": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
-            "xref": [],
-            "name": "hash_map_value",
+            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 54, locStartCol = 1, locEndLine = 54, locEndCol = 6}",
             "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 55, locStartCol = 3, locEndLine = 55, locEndCol = 17}",
+            "name": "hash_map_value",
             "type": {
-                "val_type": {
-                    "type": "string"
-                },
                 "key_type": {
                     "type": "string"
                 },
-                "type": "map"
+                "type": "map",
+                "val_type": {
+                    "type": "string"
+                }
             },
-            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 54, locStartCol = 1, locEndLine = 54, locEndCol = 6}"
-        },
-        {
             "value": {
                 "literal": {
+                    "type": "map",
                     "value": [
                         {
-                            "field_name": "a",
-                            "field_type": {
-                                "type": "i16"
-                            },
-                            "field_value": {
+                            "key": {
                                 "literal": {
-                                    "value": 1,
-                                    "type": "i16"
+                                    "type": "string",
+                                    "value": "a"
+                                }
+                            },
+                            "val": {
+                                "literal": {
+                                    "type": "string",
+                                    "value": "A"
                                 }
                             }
                         },
                         {
-                            "field_name": "b",
-                            "field_type": {
-                                "type": "i32"
-                            },
-                            "field_value": {
+                            "key": {
                                 "literal": {
-                                    "value": 2,
-                                    "type": "i32"
+                                    "type": "string",
+                                    "value": "b"
                                 }
-                            }
-                        },
-                        {
-                            "field_name": "c",
-                            "field_type": {
-                                "type": "i64"
                             },
-                            "field_value": {
+                            "val": {
                                 "literal": {
-                                    "string": "3",
-                                    "value": 3,
-                                    "type": "i64"
+                                    "type": "string",
+                                    "value": "B"
                                 }
                             }
                         }
-                    ],
-                    "type": "struct"
+                    ]
                 }
             },
+            "xref": []
+        },
+        {
             "ann_type": {
                 "anns": null,
                 "loc": [
@@ -750,26 +552,19 @@
                     "name": "B"
                 }
             },
-            "xref": [
-                {
-                    "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
-                    "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 57, locStartCol = 7, locEndLine = 57, locEndCol = 8}"
-                }
-            ],
-            "name": "struct_value",
+            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 57, locStartCol = 1, locEndLine = 57, locEndCol = 6}",
             "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 57, locStartCol = 9, locEndLine = 57, locEndCol = 21}",
+            "name": "struct_value",
             "type": {
+                "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
                 "name": {
                     "name": "B"
                 },
-                "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
                 "type": "struct"
             },
-            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 57, locStartCol = 1, locEndLine = 57, locEndCol = 6}"
-        },
-        {
             "value": {
                 "literal": {
+                    "type": "struct",
                     "value": [
                         {
                             "field_name": "a",
@@ -778,8 +573,8 @@
                             },
                             "field_value": {
                                 "literal": {
-                                    "value": 1,
-                                    "type": "i16"
+                                    "type": "i16",
+                                    "value": 1
                                 }
                             }
                         },
@@ -790,8 +585,8 @@
                             },
                             "field_value": {
                                 "literal": {
-                                    "value": 2,
-                                    "type": "i32"
+                                    "type": "i32",
+                                    "value": 2
                                 }
                             }
                         },
@@ -803,15 +598,22 @@
                             "field_value": {
                                 "literal": {
                                     "string": "3",
-                                    "value": 3,
-                                    "type": "i64"
+                                    "type": "i64",
+                                    "value": 3
                                 }
                             }
                         }
-                    ],
-                    "type": "struct"
+                    ]
                 }
             },
+            "xref": [
+                {
+                    "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 57, locStartCol = 7, locEndLine = 57, locEndCol = 8}",
+                    "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}"
+                }
+            ]
+        },
+        {
             "ann_type": {
                 "anns": null,
                 "loc": [
@@ -821,43 +623,107 @@
                     "name": "B"
                 }
             },
-            "xref": [
-                {
-                    "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
-                    "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 58, locStartCol = 7, locEndLine = 58, locEndCol = 8}"
-                }
-            ],
-            "name": "explicit_struct_value",
+            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 58, locStartCol = 1, locEndLine = 58, locEndCol = 6}",
             "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 58, locStartCol = 9, locEndLine = 58, locEndCol = 30}",
+            "name": "explicit_struct_value",
             "type": {
+                "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
                 "name": {
                     "name": "B"
                 },
-                "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
                 "type": "struct"
             },
-            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 58, locStartCol = 1, locEndLine = 58, locEndCol = 6}"
-        },
-        {
             "value": {
                 "literal": {
+                    "type": "struct",
+                    "value": [
+                        {
+                            "field_name": "a",
+                            "field_type": {
+                                "type": "i16"
+                            },
+                            "field_value": {
+                                "literal": {
+                                    "type": "i16",
+                                    "value": 1
+                                }
+                            }
+                        },
+                        {
+                            "field_name": "b",
+                            "field_type": {
+                                "type": "i32"
+                            },
+                            "field_value": {
+                                "literal": {
+                                    "type": "i32",
+                                    "value": 2
+                                }
+                            }
+                        },
+                        {
+                            "field_name": "c",
+                            "field_type": {
+                                "type": "i64"
+                            },
+                            "field_value": {
+                                "literal": {
+                                    "string": "3",
+                                    "type": "i64",
+                                    "value": 3
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "xref": [
+                {
+                    "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 58, locStartCol = 7, locEndLine = 58, locEndCol = 8}",
+                    "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}"
+                }
+            ]
+        },
+        {
+            "ann_type": {
+                "anns": null,
+                "loc": [
+                    "Loc {locFile = \"test/if/b.thrift\", locStartLine = 59, locStartCol = 7, locEndLine = 59, locEndCol = 8}"
+                ],
+                "type": {
+                    "name": "C"
+                }
+            },
+            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 59, locStartCol = 1, locEndLine = 59, locEndCol = 6}",
+            "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 59, locStartCol = 9, locEndLine = 59, locEndCol = 37}",
+            "name": "explicit_nested_struct_value",
+            "type": {
+                "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 9, locStartCol = 8, locEndLine = 9, locEndCol = 9}",
+                "name": {
+                    "name": "C"
+                },
+                "type": "struct"
+            },
+            "value": {
+                "literal": {
+                    "type": "struct",
                     "value": [
                         {
                             "field_name": "x",
                             "field_type": {
                                 "inner_type": {
+                                    "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
                                     "name": {
                                         "name": "Number"
                                     },
-                                    "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
                                     "type": "enum"
                                 },
                                 "type": "list"
                             },
                             "field_value": {
                                 "literal": {
-                                    "value": [],
-                                    "type": "list"
+                                    "type": "list",
+                                    "value": []
                                 }
                             }
                         },
@@ -865,32 +731,33 @@
                             "field_name": "y",
                             "field_type": {
                                 "inner_type": {
+                                    "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 22, locStartCol = 6, locEndLine = 22, locEndCol = 19}",
                                     "name": {
                                         "name": "Number_Strict"
                                     },
-                                    "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 22, locStartCol = 6, locEndLine = 22, locEndCol = 19}",
                                     "type": "enum"
                                 },
                                 "type": "list"
                             },
                             "field_value": {
                                 "literal": {
-                                    "value": [],
-                                    "type": "list"
+                                    "type": "list",
+                                    "value": []
                                 }
                             }
                         },
                         {
                             "field_name": "z",
                             "field_type": {
+                                "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
                                 "name": {
                                     "name": "B"
                                 },
-                                "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
                                 "type": "struct"
                             },
                             "field_value": {
                                 "literal": {
+                                    "type": "struct",
                                     "value": [
                                         {
                                             "field_name": "a",
@@ -899,8 +766,8 @@
                                             },
                                             "field_value": {
                                                 "literal": {
-                                                    "value": 1,
-                                                    "type": "i16"
+                                                    "type": "i16",
+                                                    "value": 1
                                                 }
                                             }
                                         },
@@ -911,8 +778,8 @@
                                             },
                                             "field_value": {
                                                 "literal": {
-                                                    "value": 2,
-                                                    "type": "i32"
+                                                    "type": "i32",
+                                                    "value": 2
                                                 }
                                             }
                                         },
@@ -924,123 +791,256 @@
                                             "field_value": {
                                                 "literal": {
                                                     "string": "3",
-                                                    "value": 3,
-                                                    "type": "i64"
+                                                    "type": "i64",
+                                                    "value": 3
                                                 }
                                             }
                                         }
-                                    ],
-                                    "type": "struct"
+                                    ]
                                 }
                             }
                         }
-                    ],
-                    "type": "struct"
-                }
-            },
-            "ann_type": {
-                "anns": null,
-                "loc": [
-                    "Loc {locFile = \"test/if/b.thrift\", locStartLine = 59, locStartCol = 7, locEndLine = 59, locEndCol = 8}"
-                ],
-                "type": {
-                    "name": "C"
+                    ]
                 }
             },
             "xref": [
                 {
-                    "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 9, locStartCol = 8, locEndLine = 9, locEndCol = 9}",
-                    "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 59, locStartCol = 7, locEndLine = 59, locEndCol = 8}"
+                    "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 59, locStartCol = 7, locEndLine = 59, locEndCol = 8}",
+                    "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 9, locStartCol = 8, locEndLine = 9, locEndCol = 9}"
                 }
-            ],
-            "name": "explicit_nested_struct_value",
-            "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 59, locStartCol = 9, locEndLine = 59, locEndCol = 37}",
-            "type": {
-                "name": {
-                    "name": "C"
-                },
-                "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 9, locStartCol = 8, locEndLine = 9, locEndCol = 9}",
-                "type": "struct"
-            },
-            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 59, locStartCol = 1, locEndLine = 59, locEndCol = 6}"
+            ]
         }
     ],
-    "name": "b",
-    "includes": [],
     "enums": [
         {
-            "is_psuedo": false,
-            "name": "Number",
             "constants": [
                 {
-                    "value": 0,
+                    "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 16, locStartCol = 3, locEndLine = 16, locEndCol = 7}",
                     "name": "Zero",
-                    "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 16, locStartCol = 3, locEndLine = 16, locEndCol = 7}"
+                    "value": 0
                 },
                 {
-                    "value": 1,
+                    "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 17, locStartCol = 3, locEndLine = 17, locEndCol = 6}",
                     "name": "One",
-                    "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 17, locStartCol = 3, locEndLine = 17, locEndCol = 6}"
+                    "value": 1
                 },
                 {
-                    "value": 2,
+                    "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 18, locStartCol = 3, locEndLine = 18, locEndCol = 6}",
                     "name": "Two",
-                    "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 18, locStartCol = 3, locEndLine = 18, locEndCol = 6}"
+                    "value": 2
                 },
                 {
-                    "value": 3,
+                    "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 19, locStartCol = 3, locEndLine = 19, locEndCol = 8}",
                     "name": "Three",
-                    "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 19, locStartCol = 3, locEndLine = 19, locEndCol = 8}"
+                    "value": 3
                 }
             ],
+            "is_psuedo": false,
+            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 1, locEndLine = 15, locEndCol = 5}",
             "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
-            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 1, locEndLine = 15, locEndCol = 5}"
+            "name": "Number"
         },
         {
-            "is_psuedo": false,
-            "name": "Number_Strict",
             "constants": [
                 {
-                    "value": 0,
+                    "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 23, locStartCol = 3, locEndLine = 23, locEndCol = 7}",
                     "name": "Zero",
-                    "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 23, locStartCol = 3, locEndLine = 23, locEndCol = 7}"
+                    "value": 0
                 }
             ],
+            "is_psuedo": false,
+            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 22, locStartCol = 1, locEndLine = 22, locEndCol = 5}",
             "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 22, locStartCol = 6, locEndLine = 22, locEndCol = 19}",
-            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 22, locStartCol = 1, locEndLine = 22, locEndCol = 5}"
+            "name": "Number_Strict"
         },
         {
-            "is_psuedo": false,
-            "name": "Number_Discontinuous",
             "constants": [
                 {
-                    "value": 5,
+                    "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 27, locStartCol = 3, locEndLine = 27, locEndCol = 7}",
                     "name": "Five",
-                    "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 27, locStartCol = 3, locEndLine = 27, locEndCol = 7}"
+                    "value": 5
                 },
                 {
-                    "value": 0,
+                    "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 28, locStartCol = 3, locEndLine = 28, locEndCol = 7}",
                     "name": "Zero",
-                    "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 28, locStartCol = 3, locEndLine = 28, locEndCol = 7}"
+                    "value": 0
                 }
             ],
+            "is_psuedo": false,
+            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 26, locStartCol = 1, locEndLine = 26, locEndCol = 5}",
             "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 26, locStartCol = 6, locEndLine = 26, locEndCol = 26}",
-            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 26, locStartCol = 1, locEndLine = 26, locEndCol = 5}"
+            "name": "Number_Discontinuous"
         },
         {
-            "is_psuedo": false,
-            "name": "Number_Empty",
             "constants": [],
+            "is_psuedo": false,
+            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 31, locStartCol = 1, locEndLine = 31, locEndCol = 5}",
             "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 31, locStartCol = 6, locEndLine = 31, locEndCol = 18}",
-            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 31, locStartCol = 1, locEndLine = 31, locEndCol = 5}"
+            "name": "Number_Empty"
         }
     ],
+    "includes": [],
+    "name": "b",
     "options": {
-        "path": "test/if/a.thrift",
-        "include_path": ".",
         "genfiles": null,
+        "include_path": ".",
         "out_path": "test/fixtures/gen-basic-loc",
+        "path": "test/if/a.thrift",
         "recursive": true
     },
-    "services": []
+    "path": "test/if/b.thrift",
+    "services": [],
+    "structs": [
+        {
+            "fields": [
+                {
+                    "default_value": {
+                        "literal": {
+                            "type": "i16",
+                            "value": 1
+                        }
+                    },
+                    "id": 1,
+                    "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 4, locStartCol = 10, locEndLine = 4, locEndCol = 11}",
+                    "name": "a",
+                    "requiredness": "default",
+                    "type": {
+                        "type": "i16"
+                    },
+                    "xref": []
+                },
+                {
+                    "id": 2,
+                    "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 5, locStartCol = 10, locEndLine = 5, locEndCol = 11}",
+                    "name": "b",
+                    "requiredness": "default",
+                    "type": {
+                        "type": "i32"
+                    },
+                    "xref": []
+                },
+                {
+                    "id": 3,
+                    "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 6, locStartCol = 10, locEndLine = 6, locEndCol = 11}",
+                    "name": "c",
+                    "requiredness": "default",
+                    "type": {
+                        "type": "i64"
+                    },
+                    "xref": []
+                }
+            ],
+            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 1, locEndLine = 3, locEndCol = 7}",
+            "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
+            "name": "B",
+            "struct_type": "STRUCT"
+        },
+        {
+            "fields": [
+                {
+                    "id": 1,
+                    "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 10, locStartCol = 19, locEndLine = 10, locEndCol = 20}",
+                    "name": "x",
+                    "requiredness": "default",
+                    "type": {
+                        "inner_type": {
+                            "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
+                            "name": {
+                                "name": "Number"
+                            },
+                            "type": "enum"
+                        },
+                        "type": "list"
+                    },
+                    "xref": [
+                        {
+                            "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 10, locStartCol = 11, locEndLine = 10, locEndCol = 17}",
+                            "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}"
+                        }
+                    ]
+                },
+                {
+                    "id": 2,
+                    "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 11, locStartCol = 26, locEndLine = 11, locEndCol = 27}",
+                    "name": "y",
+                    "requiredness": "default",
+                    "type": {
+                        "inner_type": {
+                            "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 22, locStartCol = 6, locEndLine = 22, locEndCol = 19}",
+                            "name": {
+                                "name": "Number_Strict"
+                            },
+                            "type": "enum"
+                        },
+                        "type": "list"
+                    },
+                    "xref": [
+                        {
+                            "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 11, locStartCol = 11, locEndLine = 11, locEndCol = 24}",
+                            "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 22, locStartCol = 6, locEndLine = 22, locEndCol = 19}"
+                        }
+                    ]
+                },
+                {
+                    "id": 3,
+                    "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 12, locStartCol = 8, locEndLine = 12, locEndCol = 9}",
+                    "name": "z",
+                    "requiredness": "default",
+                    "type": {
+                        "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
+                        "name": {
+                            "name": "B"
+                        },
+                        "type": "struct"
+                    },
+                    "xref": [
+                        {
+                            "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 12, locStartCol = 6, locEndLine = 12, locEndCol = 7}",
+                            "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}"
+                        }
+                    ]
+                }
+            ],
+            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 9, locStartCol = 1, locEndLine = 9, locEndCol = 7}",
+            "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 9, locStartCol = 8, locEndLine = 9, locEndCol = 9}",
+            "name": "C",
+            "struct_type": "STRUCT"
+        }
+    ],
+    "typedefs": [
+        {
+            "ann_type": {
+                "anns": null,
+                "loc": [
+                    "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 9, locEndLine = 34, locEndCol = 12}"
+                ],
+                "type": {
+                    "type": "i64"
+                }
+            },
+            "anns": {
+                "loc_ann_list": [
+                    {
+                        "ann_tag": "hs.newtype",
+                        "ann_type": "SimpleAnn",
+                        "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 18, locEndLine = 34, locEndCol = 28}",
+                        "sep": {
+                            "sep_type": "NoSep"
+                        }
+                    }
+                ],
+                "loc_close": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 28, locEndLine = 34, locEndCol = 29}",
+                "loc_open": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 17, locEndLine = 34, locEndCol = 18}"
+            },
+            "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 1, locEndLine = 34, locEndCol = 8}",
+            "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 13, locEndLine = 34, locEndCol = 16}",
+            "name": "Int",
+            "newtype": true,
+            "type": {
+                "type": "i64"
+            },
+            "xref": []
+        }
+    ],
+    "unions": []
 }

--- a/compiler/test/fixtures/gen-basic/a.ast
+++ b/compiler/test/fixtures/gen-basic/a.ast
@@ -1,193 +1,6 @@
 {
-    "typedefs": [
-        {
-            "newtype": false,
-            "name": "T",
-            "type": {
-                "type": "i64"
-            }
-        }
-    ],
-    "structs": [
-        {
-            "name": "A",
-            "struct_type": "STRUCT",
-            "fields": [
-                {
-                    "default_value": {
-                        "named_constant": {
-                            "name": "a"
-                        }
-                    },
-                    "name": "a",
-                    "requiredness": "default",
-                    "id": 1,
-                    "type": {
-                        "inner_type": {
-                            "type": "i64"
-                        },
-                        "name": {
-                            "name": "T"
-                        },
-                        "type": "typedef"
-                    }
-                },
-                {
-                    "default_value": {
-                        "named_constant": {
-                            "name": "b"
-                        }
-                    },
-                    "name": "b",
-                    "requiredness": "default",
-                    "id": 2,
-                    "type": {
-                        "name": {
-                            "name": "B",
-                            "src": "b"
-                        },
-                        "type": "struct"
-                    }
-                },
-                {
-                    "default_value": {
-                        "named_constant": {
-                            "name": "bool_value",
-                            "src": "b"
-                        }
-                    },
-                    "name": "c",
-                    "requiredness": "default",
-                    "id": 3,
-                    "type": {
-                        "type": "bool"
-                    }
-                },
-                {
-                    "name": "d",
-                    "requiredness": "default",
-                    "id": 4,
-                    "type": {
-                        "inner_type": {
-                            "inner_type": {
-                                "type": "i32"
-                            },
-                            "type": "list"
-                        },
-                        "type": "list"
-                    }
-                },
-                {
-                    "name": "e",
-                    "requiredness": "default",
-                    "id": 5,
-                    "type": {
-                        "val_type": {
-                            "type": "string"
-                        },
-                        "key_type": {
-                            "type": "i32"
-                        },
-                        "type": "map"
-                    }
-                },
-                {
-                    "default_value": {
-                        "literal": {
-                            "value": {
-                                "name": "Two",
-                                "src": "b"
-                            },
-                            "type": "enum"
-                        }
-                    },
-                    "name": "f",
-                    "requiredness": "default",
-                    "id": 6,
-                    "type": {
-                        "name": {
-                            "name": "Number",
-                            "src": "b"
-                        },
-                        "type": "enum"
-                    }
-                },
-                {
-                    "name": "g",
-                    "requiredness": "optional",
-                    "id": 7,
-                    "type": {
-                        "type": "string"
-                    }
-                },
-                {
-                    "name": "h",
-                    "requiredness": "required",
-                    "id": 8,
-                    "type": {
-                        "type": "string"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "X",
-            "struct_type": "EXCEPTION",
-            "fields": [
-                {
-                    "name": "reason",
-                    "requiredness": "default",
-                    "id": 1,
-                    "type": {
-                        "type": "string"
-                    }
-                }
-            ]
-        }
-    ],
-    "path": "test/if/a.thrift",
-    "unions": [
-        {
-            "name": "U",
-            "fields": [
-                {
-                    "name": "x",
-                    "id": 1,
-                    "type": {
-                        "type": "byte"
-                    }
-                },
-                {
-                    "name": "y",
-                    "id": 2,
-                    "type": {
-                        "inner_type": {
-                            "type": "string"
-                        },
-                        "type": "list"
-                    }
-                },
-                {
-                    "name": "z",
-                    "id": 3,
-                    "type": {
-                        "inner_type": {
-                            "type": "i64"
-                        },
-                        "type": "set"
-                    }
-                }
-            ]
-        }
-    ],
     "consts": [
         {
-            "value": {
-                "named_constant": {
-                    "name": "i64_value",
-                    "src": "b"
-                }
-            },
             "name": "a",
             "type": {
                 "inner_type": {
@@ -197,11 +10,25 @@
                     "name": "T"
                 },
                 "type": "typedef"
+            },
+            "value": {
+                "named_constant": {
+                    "name": "i64_value",
+                    "src": "b"
+                }
             }
         },
         {
+            "name": "u",
+            "type": {
+                "name": {
+                    "name": "U"
+                },
+                "type": "union"
+            },
             "value": {
                 "literal": {
+                    "type": "union",
                     "value": {
                         "field_name": "y",
                         "field_type": {
@@ -212,6 +39,7 @@
                         },
                         "field_value": {
                             "literal": {
+                                "type": "list",
                                 "value": [
                                     {
                                         "named_constant": {
@@ -219,25 +47,25 @@
                                             "src": "b"
                                         }
                                     }
-                                ],
-                                "type": "list"
+                                ]
                             }
                         }
-                    },
-                    "type": "union"
+                    }
                 }
-            },
-            "name": "u",
-            "type": {
-                "name": {
-                    "name": "U"
-                },
-                "type": "union"
             }
         },
         {
+            "name": "b",
+            "type": {
+                "name": {
+                    "name": "B",
+                    "src": "b"
+                },
+                "type": "struct"
+            },
             "value": {
                 "literal": {
+                    "type": "struct",
                     "value": [
                         {
                             "field_name": "a",
@@ -275,22 +103,22 @@
                                 }
                             }
                         }
-                    ],
-                    "type": "struct"
+                    ]
                 }
-            },
-            "name": "b",
+            }
+        },
+        {
+            "name": "default_d",
             "type": {
                 "name": {
                     "name": "B",
                     "src": "b"
                 },
                 "type": "struct"
-            }
-        },
-        {
+            },
             "value": {
                 "literal": {
+                    "type": "struct",
                     "value": [
                         {
                             "field_name": "a",
@@ -319,29 +147,11 @@
                                 "default": null
                             }
                         }
-                    ],
-                    "type": "struct"
+                    ]
                 }
-            },
-            "name": "default_d",
-            "type": {
-                "name": {
-                    "name": "B",
-                    "src": "b"
-                },
-                "type": "struct"
             }
         },
         {
-            "value": {
-                "literal": {
-                    "value": {
-                        "name": "Zero",
-                        "src": "b"
-                    },
-                    "type": "enum"
-                }
-            },
             "name": "zero",
             "type": {
                 "name": {
@@ -349,35 +159,46 @@
                     "src": "b"
                 },
                 "type": "enum"
+            },
+            "value": {
+                "literal": {
+                    "type": "enum",
+                    "value": {
+                        "name": "Zero",
+                        "src": "b"
+                    }
+                }
             }
         }
     ],
-    "name": "a",
+    "enums": [],
     "includes": [
         "test/if/b.thrift"
     ],
-    "enums": [],
+    "name": "a",
     "options": {
-        "path": "test/if/a.thrift",
-        "include_path": ".",
         "genfiles": null,
+        "include_path": ".",
         "out_path": "test/fixtures/gen-basic",
+        "path": "test/if/a.thrift",
         "recursive": true
     },
+    "path": "test/if/a.thrift",
     "services": [
         {
-            "name": "S",
             "functions": [
                 {
                     "args": [
                         {
-                            "name": "x",
                             "id": 1,
+                            "name": "x",
                             "type": {
                                 "type": "i32"
                             }
                         }
                     ],
+                    "name": "getNumber",
+                    "oneway": false,
                     "return_type": {
                         "name": {
                             "name": "Number",
@@ -385,19 +206,19 @@
                         },
                         "type": "enum"
                     },
-                    "throws": [],
-                    "name": "getNumber",
-                    "oneway": false
+                    "throws": []
                 },
                 {
                     "args": [],
+                    "name": "doNothing",
+                    "oneway": false,
                     "return_type": {
                         "type": "void"
                     },
                     "throws": [
                         {
-                            "name": "ex",
                             "id": 1,
+                            "name": "ex",
                             "type": {
                                 "name": {
                                     "name": "X"
@@ -405,32 +226,211 @@
                                 "type": "exception"
                             }
                         }
-                    ],
-                    "name": "doNothing",
-                    "oneway": false
+                    ]
                 }
-            ]
+            ],
+            "name": "S"
         },
         {
-            "name": "ParentService",
-            "functions": []
+            "functions": [],
+            "name": "ParentService"
         },
         {
-            "super": {
-                "name": "ParentService"
-            },
-            "name": "ChildService",
             "functions": [
                 {
                     "args": [],
+                    "name": "foo",
+                    "oneway": false,
                     "return_type": {
                         "type": "i32"
                     },
-                    "throws": [],
-                    "name": "foo",
-                    "oneway": false
+                    "throws": []
                 }
-            ]
+            ],
+            "name": "ChildService",
+            "super": {
+                "name": "ParentService"
+            }
+        }
+    ],
+    "structs": [
+        {
+            "fields": [
+                {
+                    "default_value": {
+                        "named_constant": {
+                            "name": "a"
+                        }
+                    },
+                    "id": 1,
+                    "name": "a",
+                    "requiredness": "default",
+                    "type": {
+                        "inner_type": {
+                            "type": "i64"
+                        },
+                        "name": {
+                            "name": "T"
+                        },
+                        "type": "typedef"
+                    }
+                },
+                {
+                    "default_value": {
+                        "named_constant": {
+                            "name": "b"
+                        }
+                    },
+                    "id": 2,
+                    "name": "b",
+                    "requiredness": "default",
+                    "type": {
+                        "name": {
+                            "name": "B",
+                            "src": "b"
+                        },
+                        "type": "struct"
+                    }
+                },
+                {
+                    "default_value": {
+                        "named_constant": {
+                            "name": "bool_value",
+                            "src": "b"
+                        }
+                    },
+                    "id": 3,
+                    "name": "c",
+                    "requiredness": "default",
+                    "type": {
+                        "type": "bool"
+                    }
+                },
+                {
+                    "id": 4,
+                    "name": "d",
+                    "requiredness": "default",
+                    "type": {
+                        "inner_type": {
+                            "inner_type": {
+                                "type": "i32"
+                            },
+                            "type": "list"
+                        },
+                        "type": "list"
+                    }
+                },
+                {
+                    "id": 5,
+                    "name": "e",
+                    "requiredness": "default",
+                    "type": {
+                        "key_type": {
+                            "type": "i32"
+                        },
+                        "type": "map",
+                        "val_type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                {
+                    "default_value": {
+                        "literal": {
+                            "type": "enum",
+                            "value": {
+                                "name": "Two",
+                                "src": "b"
+                            }
+                        }
+                    },
+                    "id": 6,
+                    "name": "f",
+                    "requiredness": "default",
+                    "type": {
+                        "name": {
+                            "name": "Number",
+                            "src": "b"
+                        },
+                        "type": "enum"
+                    }
+                },
+                {
+                    "id": 7,
+                    "name": "g",
+                    "requiredness": "optional",
+                    "type": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "id": 8,
+                    "name": "h",
+                    "requiredness": "required",
+                    "type": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "name": "A",
+            "struct_type": "STRUCT"
+        },
+        {
+            "fields": [
+                {
+                    "id": 1,
+                    "name": "reason",
+                    "requiredness": "default",
+                    "type": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "name": "X",
+            "struct_type": "EXCEPTION"
+        }
+    ],
+    "typedefs": [
+        {
+            "name": "T",
+            "newtype": false,
+            "type": {
+                "type": "i64"
+            }
+        }
+    ],
+    "unions": [
+        {
+            "fields": [
+                {
+                    "id": 1,
+                    "name": "x",
+                    "type": {
+                        "type": "byte"
+                    }
+                },
+                {
+                    "id": 2,
+                    "name": "y",
+                    "type": {
+                        "inner_type": {
+                            "type": "string"
+                        },
+                        "type": "list"
+                    }
+                },
+                {
+                    "id": 3,
+                    "name": "z",
+                    "type": {
+                        "inner_type": {
+                            "type": "i64"
+                        },
+                        "type": "set"
+                    }
+                }
+            ],
+            "name": "U"
         }
     ]
 }

--- a/compiler/test/fixtures/gen-basic/b.ast
+++ b/compiler/test/fixtures/gen-basic/b.ast
@@ -1,221 +1,117 @@
 {
-    "typedefs": [
-        {
-            "newtype": true,
-            "name": "Int",
-            "type": {
-                "type": "i64"
-            }
-        }
-    ],
-    "structs": [
-        {
-            "name": "B",
-            "struct_type": "STRUCT",
-            "fields": [
-                {
-                    "default_value": {
-                        "literal": {
-                            "value": 1,
-                            "type": "i16"
-                        }
-                    },
-                    "name": "a",
-                    "requiredness": "default",
-                    "id": 1,
-                    "type": {
-                        "type": "i16"
-                    }
-                },
-                {
-                    "name": "b",
-                    "requiredness": "default",
-                    "id": 2,
-                    "type": {
-                        "type": "i32"
-                    }
-                },
-                {
-                    "name": "c",
-                    "requiredness": "default",
-                    "id": 3,
-                    "type": {
-                        "type": "i64"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "C",
-            "struct_type": "STRUCT",
-            "fields": [
-                {
-                    "name": "x",
-                    "requiredness": "default",
-                    "id": 1,
-                    "type": {
-                        "inner_type": {
-                            "name": {
-                                "name": "Number"
-                            },
-                            "type": "enum"
-                        },
-                        "type": "list"
-                    }
-                },
-                {
-                    "name": "y",
-                    "requiredness": "default",
-                    "id": 2,
-                    "type": {
-                        "inner_type": {
-                            "name": {
-                                "name": "Number_Strict"
-                            },
-                            "type": "enum"
-                        },
-                        "type": "list"
-                    }
-                },
-                {
-                    "name": "z",
-                    "requiredness": "default",
-                    "id": 3,
-                    "type": {
-                        "name": {
-                            "name": "B"
-                        },
-                        "type": "struct"
-                    }
-                }
-            ]
-        }
-    ],
-    "path": "test/if/b.thrift",
-    "unions": [],
     "consts": [
         {
-            "value": {
-                "literal": {
-                    "value": 0,
-                    "type": "byte"
-                }
-            },
             "name": "byte_value",
             "type": {
                 "type": "byte"
+            },
+            "value": {
+                "literal": {
+                    "type": "byte",
+                    "value": 0
+                }
             }
         },
         {
-            "value": {
-                "literal": {
-                    "value": 1,
-                    "type": "i16"
-                }
-            },
             "name": "i16_value",
             "type": {
                 "type": "i16"
+            },
+            "value": {
+                "literal": {
+                    "type": "i16",
+                    "value": 1
+                }
             }
         },
         {
-            "value": {
-                "literal": {
-                    "value": 2,
-                    "type": "i32"
-                }
-            },
             "name": "i32_value",
             "type": {
                 "type": "i32"
+            },
+            "value": {
+                "literal": {
+                    "type": "i32",
+                    "value": 2
+                }
             }
         },
         {
-            "value": {
-                "literal": {
-                    "string": "3",
-                    "value": 3,
-                    "type": "i64"
-                }
-            },
             "name": "i64_value",
             "type": {
                 "type": "i64"
+            },
+            "value": {
+                "literal": {
+                    "string": "3",
+                    "type": "i64",
+                    "value": 3
+                }
             }
         },
         {
-            "value": {
-                "literal": {
-                    "value": 0.5,
-                    "binary": "3f000000",
-                    "type": "float"
-                }
-            },
             "name": "float_value",
             "type": {
                 "type": "float"
+            },
+            "value": {
+                "literal": {
+                    "binary": "3f000000",
+                    "type": "float",
+                    "value": 0.5
+                }
             }
         },
         {
-            "value": {
-                "literal": {
-                    "value": 3.14159,
-                    "binary": "400921f9f01b866e",
-                    "type": "double"
-                }
-            },
             "name": "double_value",
             "type": {
                 "type": "double"
+            },
+            "value": {
+                "literal": {
+                    "binary": "400921f9f01b866e",
+                    "type": "double",
+                    "value": 3.14159
+                }
             }
         },
         {
-            "value": {
-                "literal": {
-                    "value": true,
-                    "type": "bool"
-                }
-            },
             "name": "bool_value",
             "type": {
                 "type": "bool"
+            },
+            "value": {
+                "literal": {
+                    "type": "bool",
+                    "value": true
+                }
             }
         },
         {
-            "value": {
-                "literal": {
-                    "value": "xxx",
-                    "type": "string"
-                }
-            },
             "name": "string_value",
             "type": {
                 "type": "string"
+            },
+            "value": {
+                "literal": {
+                    "type": "string",
+                    "value": "xxx"
+                }
             }
         },
         {
-            "value": {
-                "literal": {
-                    "value": "797979",
-                    "type": "binary"
-                }
-            },
             "name": "binary_value",
             "type": {
                 "type": "binary"
+            },
+            "value": {
+                "literal": {
+                    "type": "binary",
+                    "value": "797979"
+                }
             }
         },
         {
-            "value": {
-                "literal": {
-                    "value": {
-                        "string": "10",
-                        "value": 10,
-                        "type": "i64"
-                    },
-                    "type": "newtype"
-                }
-            },
             "name": "newtype_value",
             "type": {
                 "inner_type": {
@@ -225,17 +121,35 @@
                     "name": "Int"
                 },
                 "type": "newtype"
+            },
+            "value": {
+                "literal": {
+                    "type": "newtype",
+                    "value": {
+                        "string": "10",
+                        "type": "i64",
+                        "value": 10
+                    }
+                }
             }
         },
         {
+            "name": "list_value",
+            "type": {
+                "inner_type": {
+                    "type": "i64"
+                },
+                "type": "list"
+            },
             "value": {
                 "literal": {
+                    "type": "list",
                     "value": [
                         {
                             "literal": {
                                 "string": "0",
-                                "value": 0,
-                                "type": "i64"
+                                "type": "i64",
+                                "value": 0
                             }
                         },
                         {
@@ -243,21 +157,21 @@
                                 "name": "i64_value"
                             }
                         }
-                    ],
-                    "type": "list"
+                    ]
                 }
-            },
-            "name": "list_value",
-            "type": {
-                "inner_type": {
-                    "type": "i64"
-                },
-                "type": "list"
             }
         },
         {
+            "name": "set_value",
+            "type": {
+                "inner_type": {
+                    "type": "string"
+                },
+                "type": "set"
+            },
             "value": {
                 "literal": {
+                    "type": "set",
                     "value": [
                         {
                             "named_constant": {
@@ -266,38 +180,41 @@
                         },
                         {
                             "literal": {
-                                "value": "",
-                                "type": "string"
+                                "type": "string",
+                                "value": ""
                             }
                         }
-                    ],
-                    "type": "set"
+                    ]
                 }
-            },
-            "name": "set_value",
-            "type": {
-                "inner_type": {
-                    "type": "string"
-                },
-                "type": "set"
             }
         },
         {
+            "name": "map_value",
+            "type": {
+                "key_type": {
+                    "type": "i64"
+                },
+                "type": "map",
+                "val_type": {
+                    "type": "bool"
+                }
+            },
             "value": {
                 "literal": {
+                    "type": "map",
                     "value": [
                         {
                             "key": {
                                 "literal": {
                                     "string": "0",
-                                    "value": 0,
-                                    "type": "i64"
+                                    "type": "i64",
+                                    "value": 0
                                 }
                             },
                             "val": {
                                 "literal": {
-                                    "value": true,
-                                    "type": "bool"
+                                    "type": "bool",
+                                    "value": true
                                 }
                             }
                         },
@@ -305,135 +222,79 @@
                             "key": {
                                 "literal": {
                                     "string": "1",
-                                    "value": 1,
-                                    "type": "i64"
+                                    "type": "i64",
+                                    "value": 1
                                 }
                             },
                             "val": {
                                 "literal": {
-                                    "value": false,
-                                    "type": "bool"
+                                    "type": "bool",
+                                    "value": false
                                 }
                             }
                         }
-                    ],
-                    "type": "map"
+                    ]
                 }
-            },
-            "name": "map_value",
-            "type": {
-                "val_type": {
-                    "type": "bool"
-                },
-                "key_type": {
-                    "type": "i64"
-                },
-                "type": "map"
             }
         },
         {
-            "value": {
-                "literal": {
-                    "value": [
-                        {
-                            "key": {
-                                "literal": {
-                                    "value": "a",
-                                    "type": "string"
-                                }
-                            },
-                            "val": {
-                                "literal": {
-                                    "value": "A",
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        {
-                            "key": {
-                                "literal": {
-                                    "value": "b",
-                                    "type": "string"
-                                }
-                            },
-                            "val": {
-                                "literal": {
-                                    "value": "B",
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    ],
-                    "type": "map"
-                }
-            },
             "name": "hash_map_value",
             "type": {
-                "val_type": {
-                    "type": "string"
-                },
                 "key_type": {
                     "type": "string"
                 },
-                "type": "map"
-            }
-        },
-        {
+                "type": "map",
+                "val_type": {
+                    "type": "string"
+                }
+            },
             "value": {
                 "literal": {
+                    "type": "map",
                     "value": [
                         {
-                            "field_name": "a",
-                            "field_type": {
-                                "type": "i16"
-                            },
-                            "field_value": {
+                            "key": {
                                 "literal": {
-                                    "value": 1,
-                                    "type": "i16"
+                                    "type": "string",
+                                    "value": "a"
+                                }
+                            },
+                            "val": {
+                                "literal": {
+                                    "type": "string",
+                                    "value": "A"
                                 }
                             }
                         },
                         {
-                            "field_name": "b",
-                            "field_type": {
-                                "type": "i32"
-                            },
-                            "field_value": {
+                            "key": {
                                 "literal": {
-                                    "value": 2,
-                                    "type": "i32"
+                                    "type": "string",
+                                    "value": "b"
                                 }
-                            }
-                        },
-                        {
-                            "field_name": "c",
-                            "field_type": {
-                                "type": "i64"
                             },
-                            "field_value": {
+                            "val": {
                                 "literal": {
-                                    "string": "3",
-                                    "value": 3,
-                                    "type": "i64"
+                                    "type": "string",
+                                    "value": "B"
                                 }
                             }
                         }
-                    ],
-                    "type": "struct"
+                    ]
                 }
-            },
+            }
+        },
+        {
             "name": "struct_value",
             "type": {
                 "name": {
                     "name": "B"
                 },
                 "type": "struct"
-            }
-        },
-        {
+            },
             "value": {
                 "literal": {
+                    "type": "struct",
                     "value": [
                         {
                             "field_name": "a",
@@ -442,8 +303,8 @@
                             },
                             "field_value": {
                                 "literal": {
-                                    "value": 1,
-                                    "type": "i16"
+                                    "type": "i16",
+                                    "value": 1
                                 }
                             }
                         },
@@ -454,8 +315,8 @@
                             },
                             "field_value": {
                                 "literal": {
-                                    "value": 2,
-                                    "type": "i32"
+                                    "type": "i32",
+                                    "value": 2
                                 }
                             }
                         },
@@ -467,26 +328,79 @@
                             "field_value": {
                                 "literal": {
                                     "string": "3",
-                                    "value": 3,
-                                    "type": "i64"
+                                    "type": "i64",
+                                    "value": 3
                                 }
                             }
                         }
-                    ],
-                    "type": "struct"
+                    ]
                 }
-            },
+            }
+        },
+        {
             "name": "explicit_struct_value",
             "type": {
                 "name": {
                     "name": "B"
                 },
                 "type": "struct"
+            },
+            "value": {
+                "literal": {
+                    "type": "struct",
+                    "value": [
+                        {
+                            "field_name": "a",
+                            "field_type": {
+                                "type": "i16"
+                            },
+                            "field_value": {
+                                "literal": {
+                                    "type": "i16",
+                                    "value": 1
+                                }
+                            }
+                        },
+                        {
+                            "field_name": "b",
+                            "field_type": {
+                                "type": "i32"
+                            },
+                            "field_value": {
+                                "literal": {
+                                    "type": "i32",
+                                    "value": 2
+                                }
+                            }
+                        },
+                        {
+                            "field_name": "c",
+                            "field_type": {
+                                "type": "i64"
+                            },
+                            "field_value": {
+                                "literal": {
+                                    "string": "3",
+                                    "type": "i64",
+                                    "value": 3
+                                }
+                            }
+                        }
+                    ]
+                }
             }
         },
         {
+            "name": "explicit_nested_struct_value",
+            "type": {
+                "name": {
+                    "name": "C"
+                },
+                "type": "struct"
+            },
             "value": {
                 "literal": {
+                    "type": "struct",
                     "value": [
                         {
                             "field_name": "x",
@@ -501,8 +415,8 @@
                             },
                             "field_value": {
                                 "literal": {
-                                    "value": [],
-                                    "type": "list"
+                                    "type": "list",
+                                    "value": []
                                 }
                             }
                         },
@@ -519,8 +433,8 @@
                             },
                             "field_value": {
                                 "literal": {
-                                    "value": [],
-                                    "type": "list"
+                                    "type": "list",
+                                    "value": []
                                 }
                             }
                         },
@@ -534,6 +448,7 @@
                             },
                             "field_value": {
                                 "literal": {
+                                    "type": "struct",
                                     "value": [
                                         {
                                             "field_name": "a",
@@ -542,8 +457,8 @@
                                             },
                                             "field_value": {
                                                 "literal": {
-                                                    "value": 1,
-                                                    "type": "i16"
+                                                    "type": "i16",
+                                                    "value": 1
                                                 }
                                             }
                                         },
@@ -554,8 +469,8 @@
                                             },
                                             "field_value": {
                                                 "literal": {
-                                                    "value": 2,
-                                                    "type": "i32"
+                                                    "type": "i32",
+                                                    "value": 2
                                                 }
                                             }
                                         },
@@ -567,90 +482,175 @@
                                             "field_value": {
                                                 "literal": {
                                                     "string": "3",
-                                                    "value": 3,
-                                                    "type": "i64"
+                                                    "type": "i64",
+                                                    "value": 3
                                                 }
                                             }
                                         }
-                                    ],
-                                    "type": "struct"
+                                    ]
                                 }
                             }
                         }
-                    ],
-                    "type": "struct"
+                    ]
                 }
-            },
-            "name": "explicit_nested_struct_value",
-            "type": {
-                "name": {
-                    "name": "C"
-                },
-                "type": "struct"
             }
         }
     ],
-    "name": "b",
-    "includes": [],
     "enums": [
         {
-            "is_psuedo": false,
-            "name": "Number",
             "constants": [
                 {
-                    "value": 0,
-                    "name": "Zero"
+                    "name": "Zero",
+                    "value": 0
                 },
                 {
-                    "value": 1,
-                    "name": "One"
+                    "name": "One",
+                    "value": 1
                 },
                 {
-                    "value": 2,
-                    "name": "Two"
+                    "name": "Two",
+                    "value": 2
                 },
                 {
-                    "value": 3,
-                    "name": "Three"
+                    "name": "Three",
+                    "value": 3
                 }
-            ]
+            ],
+            "is_psuedo": false,
+            "name": "Number"
         },
         {
-            "is_psuedo": false,
-            "name": "Number_Strict",
             "constants": [
                 {
-                    "value": 0,
-                    "name": "Zero"
+                    "name": "Zero",
+                    "value": 0
                 }
-            ]
+            ],
+            "is_psuedo": false,
+            "name": "Number_Strict"
         },
         {
-            "is_psuedo": false,
-            "name": "Number_Discontinuous",
             "constants": [
                 {
-                    "value": 5,
-                    "name": "Five"
+                    "name": "Five",
+                    "value": 5
                 },
                 {
-                    "value": 0,
-                    "name": "Zero"
+                    "name": "Zero",
+                    "value": 0
                 }
-            ]
+            ],
+            "is_psuedo": false,
+            "name": "Number_Discontinuous"
         },
         {
+            "constants": [],
             "is_psuedo": false,
-            "name": "Number_Empty",
-            "constants": []
+            "name": "Number_Empty"
         }
     ],
+    "includes": [],
+    "name": "b",
     "options": {
-        "path": "test/if/a.thrift",
-        "include_path": ".",
         "genfiles": null,
+        "include_path": ".",
         "out_path": "test/fixtures/gen-basic",
+        "path": "test/if/a.thrift",
         "recursive": true
     },
-    "services": []
+    "path": "test/if/b.thrift",
+    "services": [],
+    "structs": [
+        {
+            "fields": [
+                {
+                    "default_value": {
+                        "literal": {
+                            "type": "i16",
+                            "value": 1
+                        }
+                    },
+                    "id": 1,
+                    "name": "a",
+                    "requiredness": "default",
+                    "type": {
+                        "type": "i16"
+                    }
+                },
+                {
+                    "id": 2,
+                    "name": "b",
+                    "requiredness": "default",
+                    "type": {
+                        "type": "i32"
+                    }
+                },
+                {
+                    "id": 3,
+                    "name": "c",
+                    "requiredness": "default",
+                    "type": {
+                        "type": "i64"
+                    }
+                }
+            ],
+            "name": "B",
+            "struct_type": "STRUCT"
+        },
+        {
+            "fields": [
+                {
+                    "id": 1,
+                    "name": "x",
+                    "requiredness": "default",
+                    "type": {
+                        "inner_type": {
+                            "name": {
+                                "name": "Number"
+                            },
+                            "type": "enum"
+                        },
+                        "type": "list"
+                    }
+                },
+                {
+                    "id": 2,
+                    "name": "y",
+                    "requiredness": "default",
+                    "type": {
+                        "inner_type": {
+                            "name": {
+                                "name": "Number_Strict"
+                            },
+                            "type": "enum"
+                        },
+                        "type": "list"
+                    }
+                },
+                {
+                    "id": 3,
+                    "name": "z",
+                    "requiredness": "default",
+                    "type": {
+                        "name": {
+                            "name": "B"
+                        },
+                        "type": "struct"
+                    }
+                }
+            ],
+            "name": "C",
+            "struct_type": "STRUCT"
+        }
+    ],
+    "typedefs": [
+        {
+            "name": "Int",
+            "newtype": true,
+            "type": {
+                "type": "i64"
+            }
+        }
+    ],
+    "unions": []
 }

--- a/compiler/test/fixtures/gen-basic/c.ast
+++ b/compiler/test/fixtures/gen-basic/c.ast
@@ -1,201 +1,73 @@
 {
-    "typedefs": [
-        {
-            "newtype": false,
-            "name": "annotated_string",
-            "type": {
-                "type": "string"
-            }
-        }
-    ],
-    "structs": [
-        {
-            "name": "FirstAnnotation",
-            "struct_type": "STRUCT",
-            "fields": [
-                {
-                    "name": "name",
-                    "requiredness": "default",
-                    "id": 1,
-                    "type": {
-                        "type": "string"
-                    }
-                },
-                {
-                    "default_value": {
-                        "literal": {
-                            "string": "1",
-                            "value": 1,
-                            "type": "i64"
-                        }
-                    },
-                    "name": "count",
-                    "requiredness": "default",
-                    "id": 2,
-                    "type": {
-                        "type": "i64"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "SecondAnnotation",
-            "struct_type": "STRUCT",
-            "fields": [
-                {
-                    "default_value": {
-                        "literal": {
-                            "string": "0",
-                            "value": 0,
-                            "type": "i64"
-                        }
-                    },
-                    "name": "total",
-                    "requiredness": "default",
-                    "id": 2,
-                    "type": {
-                        "type": "i64"
-                    }
-                },
-                {
-                    "name": "recurse",
-                    "requiredness": "default",
-                    "id": 3,
-                    "type": {
-                        "name": {
-                            "name": "SecondAnnotation"
-                        },
-                        "type": "struct"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "MyStruct",
-            "struct_type": "STRUCT",
-            "fields": [
-                {
-                    "name": "tag",
-                    "requiredness": "default",
-                    "id": 5,
-                    "type": {
-                        "inner_type": {
-                            "type": "string"
-                        },
-                        "name": {
-                            "name": "annotated_string"
-                        },
-                        "type": "typedef"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "MyException",
-            "struct_type": "EXCEPTION",
-            "fields": [
-                {
-                    "name": "message",
-                    "requiredness": "default",
-                    "id": 1,
-                    "type": {
-                        "type": "string"
-                    }
-                }
-            ]
-        }
-    ],
-    "path": "test/if/c.thrift",
-    "unions": [
-        {
-            "name": "MyUnion",
-            "fields": [
-                {
-                    "name": "int_value",
-                    "id": 1,
-                    "type": {
-                        "type": "i64"
-                    }
-                },
-                {
-                    "name": "string_value",
-                    "id": 2,
-                    "type": {
-                        "type": "string"
-                    }
-                }
-            ]
-        }
-    ],
     "consts": [
         {
+            "name": "MyConst",
+            "type": {
+                "key_type": {
+                    "type": "string"
+                },
+                "type": "map",
+                "val_type": {
+                    "type": "string"
+                }
+            },
             "value": {
                 "literal": {
+                    "type": "map",
                     "value": [
                         {
                             "key": {
                                 "literal": {
-                                    "value": "ENUMERATOR",
-                                    "type": "string"
+                                    "type": "string",
+                                    "value": "ENUMERATOR"
                                 }
                             },
                             "val": {
                                 "literal": {
-                                    "value": "value",
-                                    "type": "string"
+                                    "type": "string",
+                                    "value": "value"
                                 }
                             }
                         }
-                    ],
-                    "type": "map"
+                    ]
                 }
-            },
-            "name": "MyConst",
-            "type": {
-                "val_type": {
-                    "type": "string"
-                },
-                "key_type": {
-                    "type": "string"
-                },
-                "type": "map"
             }
         }
     ],
-    "name": "c",
-    "includes": [],
     "enums": [
         {
-            "is_psuedo": false,
-            "name": "MyEnum",
             "constants": [
                 {
-                    "value": 0,
-                    "name": "UNKNOWN"
+                    "name": "UNKNOWN",
+                    "value": 0
                 },
                 {
-                    "value": 1,
-                    "name": "FIRST"
+                    "name": "FIRST",
+                    "value": 1
                 }
-            ]
+            ],
+            "is_psuedo": false,
+            "name": "MyEnum"
         }
     ],
+    "includes": [],
+    "name": "c",
     "options": {
-        "path": "test/if/c.thrift",
-        "include_path": ".",
         "genfiles": null,
+        "include_path": ".",
         "out_path": "test/fixtures/gen-basic",
+        "path": "test/if/c.thrift",
         "recursive": true
     },
+    "path": "test/if/c.thrift",
     "services": [
         {
-            "name": "MyService",
             "functions": [
                 {
                     "args": [
                         {
-                            "name": "param",
                             "id": 2,
+                            "name": "param",
                             "type": {
                                 "inner_type": {
                                     "type": "string"
@@ -207,14 +79,142 @@
                             }
                         }
                     ],
+                    "name": "my_function",
+                    "oneway": false,
                     "return_type": {
                         "type": "i64"
                     },
-                    "throws": [],
-                    "name": "my_function",
-                    "oneway": false
+                    "throws": []
                 }
-            ]
+            ],
+            "name": "MyService"
+        }
+    ],
+    "structs": [
+        {
+            "fields": [
+                {
+                    "id": 1,
+                    "name": "name",
+                    "requiredness": "default",
+                    "type": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "default_value": {
+                        "literal": {
+                            "string": "1",
+                            "type": "i64",
+                            "value": 1
+                        }
+                    },
+                    "id": 2,
+                    "name": "count",
+                    "requiredness": "default",
+                    "type": {
+                        "type": "i64"
+                    }
+                }
+            ],
+            "name": "FirstAnnotation",
+            "struct_type": "STRUCT"
+        },
+        {
+            "fields": [
+                {
+                    "default_value": {
+                        "literal": {
+                            "string": "0",
+                            "type": "i64",
+                            "value": 0
+                        }
+                    },
+                    "id": 2,
+                    "name": "total",
+                    "requiredness": "default",
+                    "type": {
+                        "type": "i64"
+                    }
+                },
+                {
+                    "id": 3,
+                    "name": "recurse",
+                    "requiredness": "default",
+                    "type": {
+                        "name": {
+                            "name": "SecondAnnotation"
+                        },
+                        "type": "struct"
+                    }
+                }
+            ],
+            "name": "SecondAnnotation",
+            "struct_type": "STRUCT"
+        },
+        {
+            "fields": [
+                {
+                    "id": 5,
+                    "name": "tag",
+                    "requiredness": "default",
+                    "type": {
+                        "inner_type": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "name": "annotated_string"
+                        },
+                        "type": "typedef"
+                    }
+                }
+            ],
+            "name": "MyStruct",
+            "struct_type": "STRUCT"
+        },
+        {
+            "fields": [
+                {
+                    "id": 1,
+                    "name": "message",
+                    "requiredness": "default",
+                    "type": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "name": "MyException",
+            "struct_type": "EXCEPTION"
+        }
+    ],
+    "typedefs": [
+        {
+            "name": "annotated_string",
+            "newtype": false,
+            "type": {
+                "type": "string"
+            }
+        }
+    ],
+    "unions": [
+        {
+            "fields": [
+                {
+                    "id": 1,
+                    "name": "int_value",
+                    "type": {
+                        "type": "i64"
+                    }
+                },
+                {
+                    "id": 2,
+                    "name": "string_value",
+                    "type": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "name": "MyUnion"
         }
     ]
 }

--- a/compiler/test/fixtures/gen-single-out-loc/a.ast
+++ b/compiler/test/fixtures/gen-single-out-loc/a.ast
@@ -1,252 +1,7 @@
 [
     {
-        "typedefs": [
-            {
-                "newtype": false,
-                "anns": null,
-                "ann_type": {
-                    "anns": null,
-                    "loc": [
-                        "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 9, locEndLine = 7, locEndCol = 12}"
-                    ],
-                    "type": {
-                        "type": "i64"
-                    }
-                },
-                "xref": [],
-                "name": "T",
-                "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 13, locEndLine = 7, locEndCol = 14}",
-                "type": {
-                    "type": "i64"
-                },
-                "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 1, locEndLine = 7, locEndCol = 8}"
-            }
-        ],
-        "structs": [
-            {
-                "name": "A",
-                "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 9, locStartCol = 8, locEndLine = 9, locEndCol = 9}",
-                "struct_type": "STRUCT",
-                "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 9, locStartCol = 1, locEndLine = 9, locEndCol = 7}",
-                "fields": [
-                    {
-                        "default_value": {
-                            "named_constant": {
-                                "name": "a"
-                            }
-                        },
-                        "xref": [
-                            {
-                                "rLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 13, locEndLine = 7, locEndCol = 14}",
-                                "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 10, locStartCol = 6, locEndLine = 10, locEndCol = 7}"
-                            }
-                        ],
-                        "name": "a",
-                        "requiredness": "default",
-                        "id": 1,
-                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 10, locStartCol = 8, locEndLine = 10, locEndCol = 9}",
-                        "type": {
-                            "inner_type": {
-                                "type": "i64"
-                            },
-                            "name": {
-                                "name": "T"
-                            },
-                            "loc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 13, locEndLine = 7, locEndCol = 14}",
-                            "type": "typedef"
-                        }
-                    },
-                    {
-                        "default_value": {
-                            "named_constant": {
-                                "name": "b"
-                            }
-                        },
-                        "xref": [
-                            {
-                                "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
-                                "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 11, locStartCol = 6, locEndLine = 11, locEndCol = 9}"
-                            }
-                        ],
-                        "name": "b",
-                        "requiredness": "default",
-                        "id": 2,
-                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 11, locStartCol = 10, locEndLine = 11, locEndCol = 11}",
-                        "type": {
-                            "name": {
-                                "name": "B",
-                                "src": "b"
-                            },
-                            "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
-                            "type": "struct"
-                        }
-                    },
-                    {
-                        "default_value": {
-                            "named_constant": {
-                                "name": "bool_value",
-                                "src": "b"
-                            }
-                        },
-                        "xref": [],
-                        "name": "c",
-                        "requiredness": "default",
-                        "id": 3,
-                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 12, locStartCol = 11, locEndLine = 12, locEndCol = 12}",
-                        "type": {
-                            "type": "bool"
-                        }
-                    },
-                    {
-                        "xref": [],
-                        "name": "d",
-                        "requiredness": "default",
-                        "id": 4,
-                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 13, locStartCol = 22, locEndLine = 13, locEndCol = 23}",
-                        "type": {
-                            "inner_type": {
-                                "inner_type": {
-                                    "type": "i32"
-                                },
-                                "type": "list"
-                            },
-                            "type": "list"
-                        }
-                    },
-                    {
-                        "xref": [],
-                        "name": "e",
-                        "requiredness": "default",
-                        "id": 5,
-                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 14, locStartCol = 23, locEndLine = 14, locEndCol = 24}",
-                        "type": {
-                            "val_type": {
-                                "type": "string"
-                            },
-                            "key_type": {
-                                "type": "i32"
-                            },
-                            "type": "map"
-                        }
-                    },
-                    {
-                        "default_value": {
-                            "literal": {
-                                "value": {
-                                    "name": "Two",
-                                    "src": "b"
-                                },
-                                "type": "enum"
-                            }
-                        },
-                        "xref": [
-                            {
-                                "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
-                                "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 14}"
-                            }
-                        ],
-                        "name": "f",
-                        "requiredness": "default",
-                        "id": 6,
-                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 15, locStartCol = 15, locEndLine = 15, locEndCol = 16}",
-                        "type": {
-                            "name": {
-                                "name": "Number",
-                                "src": "b"
-                            },
-                            "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
-                            "type": "enum"
-                        }
-                    },
-                    {
-                        "xref": [],
-                        "name": "g",
-                        "requiredness": "optional",
-                        "id": 7,
-                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 16, locStartCol = 22, locEndLine = 16, locEndCol = 23}",
-                        "type": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "xref": [],
-                        "name": "h",
-                        "requiredness": "required",
-                        "id": 8,
-                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 17, locStartCol = 22, locEndLine = 17, locEndCol = 23}",
-                        "type": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            },
-            {
-                "name": "X",
-                "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 26, locStartCol = 11, locEndLine = 26, locEndCol = 12}",
-                "struct_type": "EXCEPTION",
-                "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 26, locStartCol = 1, locEndLine = 26, locEndCol = 10}",
-                "fields": [
-                    {
-                        "xref": [],
-                        "name": "reason",
-                        "requiredness": "default",
-                        "id": 1,
-                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 27, locStartCol = 13, locEndLine = 27, locEndCol = 19}",
-                        "type": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        ],
-        "path": "test/if/a.thrift",
-        "unions": [
-            {
-                "name": "U",
-                "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 20, locStartCol = 7, locEndLine = 20, locEndCol = 8}",
-                "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 20, locStartCol = 1, locEndLine = 20, locEndCol = 6}",
-                "fields": [
-                    {
-                        "name": "x",
-                        "id": 1,
-                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 21, locStartCol = 11, locEndLine = 21, locEndCol = 12}",
-                        "type": {
-                            "type": "byte"
-                        }
-                    },
-                    {
-                        "name": "y",
-                        "id": 2,
-                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 22, locStartCol = 19, locEndLine = 22, locEndCol = 20}",
-                        "type": {
-                            "inner_type": {
-                                "type": "string"
-                            },
-                            "type": "list"
-                        }
-                    },
-                    {
-                        "name": "z",
-                        "id": 3,
-                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 23, locStartCol = 15, locEndLine = 23, locEndCol = 16}",
-                        "type": {
-                            "inner_type": {
-                                "type": "i64"
-                            },
-                            "type": "set"
-                        }
-                    }
-                ]
-            }
-        ],
         "consts": [
             {
-                "value": {
-                    "named_constant": {
-                        "name": "i64_value",
-                        "src": "b"
-                    }
-                },
                 "ann_type": {
                     "anns": null,
                     "loc": [
@@ -256,33 +11,59 @@
                         "name": "T"
                     }
                 },
-                "xref": [
-                    {
-                        "rLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 13, locEndLine = 7, locEndCol = 14}",
-                        "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 30, locStartCol = 7, locEndLine = 30, locEndCol = 8}"
-                    },
-                    {
-                        "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 40, locStartCol = 11, locEndLine = 40, locEndCol = 20}",
-                        "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 30, locStartCol = 13, locEndLine = 30, locEndCol = 24}"
-                    }
-                ],
-                "name": "a",
+                "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 30, locStartCol = 1, locEndLine = 30, locEndCol = 6}",
                 "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 30, locStartCol = 9, locEndLine = 30, locEndCol = 10}",
+                "name": "a",
                 "type": {
                     "inner_type": {
                         "type": "i64"
                     },
+                    "loc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 13, locEndLine = 7, locEndCol = 14}",
                     "name": {
                         "name": "T"
                     },
-                    "loc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 13, locEndLine = 7, locEndCol = 14}",
                     "type": "typedef"
                 },
-                "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 30, locStartCol = 1, locEndLine = 30, locEndCol = 6}"
+                "value": {
+                    "named_constant": {
+                        "name": "i64_value",
+                        "src": "b"
+                    }
+                },
+                "xref": [
+                    {
+                        "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 30, locStartCol = 7, locEndLine = 30, locEndCol = 8}",
+                        "rLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 13, locEndLine = 7, locEndCol = 14}"
+                    },
+                    {
+                        "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 30, locStartCol = 13, locEndLine = 30, locEndCol = 24}",
+                        "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 40, locStartCol = 11, locEndLine = 40, locEndCol = 20}"
+                    }
+                ]
             },
             {
+                "ann_type": {
+                    "anns": null,
+                    "loc": [
+                        "Loc {locFile = \"test/if/a.thrift\", locStartLine = 32, locStartCol = 7, locEndLine = 32, locEndCol = 8}"
+                    ],
+                    "type": {
+                        "name": "U"
+                    }
+                },
+                "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 32, locStartCol = 1, locEndLine = 32, locEndCol = 6}",
+                "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 32, locStartCol = 9, locEndLine = 32, locEndCol = 10}",
+                "name": "u",
+                "type": {
+                    "loc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 20, locStartCol = 7, locEndLine = 20, locEndCol = 8}",
+                    "name": {
+                        "name": "U"
+                    },
+                    "type": "union"
+                },
                 "value": {
                     "literal": {
+                        "type": "union",
                         "value": {
                             "field_name": "y",
                             "field_type": {
@@ -293,6 +74,7 @@
                             },
                             "field_value": {
                                 "literal": {
+                                    "type": "list",
                                     "value": [
                                         {
                                             "named_constant": {
@@ -300,43 +82,43 @@
                                                 "src": "b"
                                             }
                                         }
-                                    ],
-                                    "type": "list"
+                                    ]
                                 }
                             }
-                        },
-                        "type": "union"
-                    }
-                },
-                "ann_type": {
-                    "anns": null,
-                    "loc": [
-                        "Loc {locFile = \"test/if/a.thrift\", locStartLine = 32, locStartCol = 7, locEndLine = 32, locEndCol = 8}"
-                    ],
-                    "type": {
-                        "name": "U"
+                        }
                     }
                 },
                 "xref": [
                     {
-                        "rLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 20, locStartCol = 7, locEndLine = 20, locEndCol = 8}",
-                        "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 32, locStartCol = 7, locEndLine = 32, locEndCol = 8}"
+                        "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 32, locStartCol = 7, locEndLine = 32, locEndCol = 8}",
+                        "rLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 20, locStartCol = 7, locEndLine = 20, locEndCol = 8}"
                     }
-                ],
-                "name": "u",
-                "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 32, locStartCol = 9, locEndLine = 32, locEndCol = 10}",
-                "type": {
-                    "name": {
-                        "name": "U"
-                    },
-                    "loc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 20, locStartCol = 7, locEndLine = 20, locEndCol = 8}",
-                    "type": "union"
-                },
-                "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 32, locStartCol = 1, locEndLine = 32, locEndCol = 6}"
+                ]
             },
             {
+                "ann_type": {
+                    "anns": null,
+                    "loc": [
+                        "Loc {locFile = \"test/if/a.thrift\", locStartLine = 34, locStartCol = 7, locEndLine = 34, locEndCol = 10}"
+                    ],
+                    "type": {
+                        "name": "b.B"
+                    }
+                },
+                "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 34, locStartCol = 1, locEndLine = 34, locEndCol = 6}",
+                "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 34, locStartCol = 11, locEndLine = 34, locEndCol = 12}",
+                "name": "b",
+                "type": {
+                    "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
+                    "name": {
+                        "name": "B",
+                        "src": "b"
+                    },
+                    "type": "struct"
+                },
                 "value": {
                     "literal": {
+                        "type": "struct",
                         "value": [
                             {
                                 "field_name": "a",
@@ -374,40 +156,40 @@
                                     }
                                 }
                             }
-                        ],
-                        "type": "struct"
+                        ]
                     }
                 },
+                "xref": [
+                    {
+                        "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 34, locStartCol = 7, locEndLine = 34, locEndCol = 10}",
+                        "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}"
+                    }
+                ]
+            },
+            {
                 "ann_type": {
                     "anns": null,
                     "loc": [
-                        "Loc {locFile = \"test/if/a.thrift\", locStartLine = 34, locStartCol = 7, locEndLine = 34, locEndCol = 10}"
+                        "Loc {locFile = \"test/if/a.thrift\", locStartLine = 40, locStartCol = 7, locEndLine = 40, locEndCol = 10}"
                     ],
                     "type": {
                         "name": "b.B"
                     }
                 },
-                "xref": [
-                    {
-                        "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
-                        "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 34, locStartCol = 7, locEndLine = 34, locEndCol = 10}"
-                    }
-                ],
-                "name": "b",
-                "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 34, locStartCol = 11, locEndLine = 34, locEndCol = 12}",
+                "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 40, locStartCol = 1, locEndLine = 40, locEndCol = 6}",
+                "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 40, locStartCol = 11, locEndLine = 40, locEndCol = 20}",
+                "name": "default_d",
                 "type": {
+                    "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
                     "name": {
                         "name": "B",
                         "src": "b"
                     },
-                    "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
                     "type": "struct"
                 },
-                "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 34, locStartCol = 1, locEndLine = 34, locEndCol = 6}"
-            },
-            {
                 "value": {
                     "literal": {
+                        "type": "struct",
                         "value": [
                             {
                                 "field_name": "a",
@@ -436,47 +218,17 @@
                                     "default": null
                                 }
                             }
-                        ],
-                        "type": "struct"
-                    }
-                },
-                "ann_type": {
-                    "anns": null,
-                    "loc": [
-                        "Loc {locFile = \"test/if/a.thrift\", locStartLine = 40, locStartCol = 7, locEndLine = 40, locEndCol = 10}"
-                    ],
-                    "type": {
-                        "name": "b.B"
+                        ]
                     }
                 },
                 "xref": [
                     {
-                        "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
-                        "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 40, locStartCol = 7, locEndLine = 40, locEndCol = 10}"
+                        "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 40, locStartCol = 7, locEndLine = 40, locEndCol = 10}",
+                        "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}"
                     }
-                ],
-                "name": "default_d",
-                "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 40, locStartCol = 11, locEndLine = 40, locEndCol = 20}",
-                "type": {
-                    "name": {
-                        "name": "B",
-                        "src": "b"
-                    },
-                    "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
-                    "type": "struct"
-                },
-                "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 40, locStartCol = 1, locEndLine = 40, locEndCol = 6}"
+                ]
             },
             {
-                "value": {
-                    "literal": {
-                        "value": {
-                            "name": "Zero",
-                            "src": "b"
-                        },
-                        "type": "enum"
-                    }
-                },
                 "ann_type": {
                     "anns": null,
                     "loc": [
@@ -486,294 +238,382 @@
                         "name": "b.Number"
                     }
                 },
-                "xref": [
-                    {
-                        "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
-                        "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 42, locStartCol = 7, locEndLine = 42, locEndCol = 15}"
-                    },
-                    {
-                        "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 16, locStartCol = 3, locEndLine = 16, locEndCol = 7}",
-                        "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 42, locStartCol = 23, locEndLine = 42, locEndCol = 29}"
-                    }
-                ],
-                "name": "zero",
+                "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 42, locStartCol = 1, locEndLine = 42, locEndCol = 6}",
                 "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 42, locStartCol = 16, locEndLine = 42, locEndCol = 20}",
+                "name": "zero",
                 "type": {
+                    "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
                     "name": {
                         "name": "Number",
                         "src": "b"
                     },
-                    "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
                     "type": "enum"
                 },
-                "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 42, locStartCol = 1, locEndLine = 42, locEndCol = 6}"
+                "value": {
+                    "literal": {
+                        "type": "enum",
+                        "value": {
+                            "name": "Zero",
+                            "src": "b"
+                        }
+                    }
+                },
+                "xref": [
+                    {
+                        "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 42, locStartCol = 7, locEndLine = 42, locEndCol = 15}",
+                        "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}"
+                    },
+                    {
+                        "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 42, locStartCol = 23, locEndLine = 42, locEndCol = 29}",
+                        "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 16, locStartCol = 3, locEndLine = 16, locEndCol = 7}"
+                    }
+                ]
             }
         ],
-        "name": "a",
+        "enums": [],
         "includes": [
             "test/if/b.thrift"
         ],
-        "enums": [],
+        "name": "a",
         "options": {
-            "path": "test/if/a.thrift",
-            "include_path": ".",
             "genfiles": null,
+            "include_path": ".",
             "out_path": "test/fixtures/gen-single-out-loc",
+            "path": "test/if/a.thrift",
             "recursive": true
         },
+        "path": "test/if/a.thrift",
         "services": [
             {
-                "name": "S",
-                "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 44, locStartCol = 9, locEndLine = 44, locEndCol = 10}",
-                "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 44, locStartCol = 1, locEndLine = 44, locEndCol = 8}",
                 "functions": [
                     {
                         "args": [
                             {
-                                "xref": [],
-                                "name": "x",
                                 "id": 1,
                                 "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 46, locStartCol = 29, locEndLine = 46, locEndCol = 30}",
+                                "name": "x",
                                 "type": {
                                     "type": "i32"
-                                }
+                                },
+                                "xref": []
                             }
                         ],
+                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 46, locStartCol = 12, locEndLine = 46, locEndCol = 21}",
+                        "name": "getNumber",
+                        "oneway": false,
                         "return_type": {
+                            "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
                             "name": {
                                 "name": "Number",
                                 "src": "b"
                             },
-                            "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
                             "type": "enum"
                         },
-                        "throws": [],
-                        "name": "getNumber",
-                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 46, locStartCol = 12, locEndLine = 46, locEndCol = 21}",
-                        "oneway": false
+                        "throws": []
                     },
                     {
                         "args": [],
+                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 48, locStartCol = 8, locEndLine = 48, locEndCol = 17}",
+                        "name": "doNothing",
+                        "oneway": false,
                         "return_type": {
                             "type": "void"
                         },
                         "throws": [
                             {
-                                "xref": [
-                                    {
-                                        "rLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 26, locStartCol = 11, locEndLine = 26, locEndCol = 12}",
-                                        "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 48, locStartCol = 31, locEndLine = 48, locEndCol = 32}"
-                                    }
-                                ],
-                                "name": "ex",
                                 "id": 1,
                                 "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 48, locStartCol = 33, locEndLine = 48, locEndCol = 35}",
+                                "name": "ex",
                                 "type": {
+                                    "loc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 26, locStartCol = 11, locEndLine = 26, locEndCol = 12}",
                                     "name": {
                                         "name": "X"
                                     },
-                                    "loc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 26, locStartCol = 11, locEndLine = 26, locEndCol = 12}",
                                     "type": "exception"
-                                }
+                                },
+                                "xref": [
+                                    {
+                                        "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 48, locStartCol = 31, locEndLine = 48, locEndCol = 32}",
+                                        "rLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 26, locStartCol = 11, locEndLine = 26, locEndCol = 12}"
+                                    }
+                                ]
                             }
-                        ],
-                        "name": "doNothing",
-                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 48, locStartCol = 8, locEndLine = 48, locEndCol = 17}",
-                        "oneway": false
+                        ]
                     }
-                ]
+                ],
+                "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 44, locStartCol = 1, locEndLine = 44, locEndCol = 8}",
+                "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 44, locStartCol = 9, locEndLine = 44, locEndCol = 10}",
+                "name": "S"
             },
             {
-                "name": "ParentService",
-                "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 52, locStartCol = 9, locEndLine = 52, locEndCol = 22}",
+                "functions": [],
                 "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 52, locStartCol = 1, locEndLine = 52, locEndCol = 8}",
-                "functions": []
+                "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 52, locStartCol = 9, locEndLine = 52, locEndCol = 22}",
+                "name": "ParentService"
             },
             {
-                "super": {
-                    "name": "ParentService"
-                },
-                "name": "ChildService",
-                "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 55, locStartCol = 9, locEndLine = 55, locEndCol = 21}",
-                "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 55, locStartCol = 1, locEndLine = 55, locEndCol = 8}",
                 "functions": [
                     {
                         "args": [],
+                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 56, locStartCol = 7, locEndLine = 56, locEndCol = 10}",
+                        "name": "foo",
+                        "oneway": false,
                         "return_type": {
                             "type": "i32"
                         },
-                        "throws": [],
-                        "name": "foo",
-                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 56, locStartCol = 7, locEndLine = 56, locEndCol = 10}",
-                        "oneway": false
+                        "throws": []
                     }
-                ]
+                ],
+                "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 55, locStartCol = 1, locEndLine = 55, locEndCol = 8}",
+                "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 55, locStartCol = 9, locEndLine = 55, locEndCol = 21}",
+                "name": "ChildService",
+                "super": {
+                    "name": "ParentService"
+                }
             }
-        ]
-    },
-    {
+        ],
+        "structs": [
+            {
+                "fields": [
+                    {
+                        "default_value": {
+                            "named_constant": {
+                                "name": "a"
+                            }
+                        },
+                        "id": 1,
+                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 10, locStartCol = 8, locEndLine = 10, locEndCol = 9}",
+                        "name": "a",
+                        "requiredness": "default",
+                        "type": {
+                            "inner_type": {
+                                "type": "i64"
+                            },
+                            "loc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 13, locEndLine = 7, locEndCol = 14}",
+                            "name": {
+                                "name": "T"
+                            },
+                            "type": "typedef"
+                        },
+                        "xref": [
+                            {
+                                "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 10, locStartCol = 6, locEndLine = 10, locEndCol = 7}",
+                                "rLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 13, locEndLine = 7, locEndCol = 14}"
+                            }
+                        ]
+                    },
+                    {
+                        "default_value": {
+                            "named_constant": {
+                                "name": "b"
+                            }
+                        },
+                        "id": 2,
+                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 11, locStartCol = 10, locEndLine = 11, locEndCol = 11}",
+                        "name": "b",
+                        "requiredness": "default",
+                        "type": {
+                            "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
+                            "name": {
+                                "name": "B",
+                                "src": "b"
+                            },
+                            "type": "struct"
+                        },
+                        "xref": [
+                            {
+                                "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 11, locStartCol = 6, locEndLine = 11, locEndCol = 9}",
+                                "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}"
+                            }
+                        ]
+                    },
+                    {
+                        "default_value": {
+                            "named_constant": {
+                                "name": "bool_value",
+                                "src": "b"
+                            }
+                        },
+                        "id": 3,
+                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 12, locStartCol = 11, locEndLine = 12, locEndCol = 12}",
+                        "name": "c",
+                        "requiredness": "default",
+                        "type": {
+                            "type": "bool"
+                        },
+                        "xref": []
+                    },
+                    {
+                        "id": 4,
+                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 13, locStartCol = 22, locEndLine = 13, locEndCol = 23}",
+                        "name": "d",
+                        "requiredness": "default",
+                        "type": {
+                            "inner_type": {
+                                "inner_type": {
+                                    "type": "i32"
+                                },
+                                "type": "list"
+                            },
+                            "type": "list"
+                        },
+                        "xref": []
+                    },
+                    {
+                        "id": 5,
+                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 14, locStartCol = 23, locEndLine = 14, locEndCol = 24}",
+                        "name": "e",
+                        "requiredness": "default",
+                        "type": {
+                            "key_type": {
+                                "type": "i32"
+                            },
+                            "type": "map",
+                            "val_type": {
+                                "type": "string"
+                            }
+                        },
+                        "xref": []
+                    },
+                    {
+                        "default_value": {
+                            "literal": {
+                                "type": "enum",
+                                "value": {
+                                    "name": "Two",
+                                    "src": "b"
+                                }
+                            }
+                        },
+                        "id": 6,
+                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 15, locStartCol = 15, locEndLine = 15, locEndCol = 16}",
+                        "name": "f",
+                        "requiredness": "default",
+                        "type": {
+                            "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
+                            "name": {
+                                "name": "Number",
+                                "src": "b"
+                            },
+                            "type": "enum"
+                        },
+                        "xref": [
+                            {
+                                "aLoc": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 14}",
+                                "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}"
+                            }
+                        ]
+                    },
+                    {
+                        "id": 7,
+                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 16, locStartCol = 22, locEndLine = 16, locEndCol = 23}",
+                        "name": "g",
+                        "requiredness": "optional",
+                        "type": {
+                            "type": "string"
+                        },
+                        "xref": []
+                    },
+                    {
+                        "id": 8,
+                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 17, locStartCol = 22, locEndLine = 17, locEndCol = 23}",
+                        "name": "h",
+                        "requiredness": "required",
+                        "type": {
+                            "type": "string"
+                        },
+                        "xref": []
+                    }
+                ],
+                "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 9, locStartCol = 1, locEndLine = 9, locEndCol = 7}",
+                "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 9, locStartCol = 8, locEndLine = 9, locEndCol = 9}",
+                "name": "A",
+                "struct_type": "STRUCT"
+            },
+            {
+                "fields": [
+                    {
+                        "id": 1,
+                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 27, locStartCol = 13, locEndLine = 27, locEndCol = 19}",
+                        "name": "reason",
+                        "requiredness": "default",
+                        "type": {
+                            "type": "string"
+                        },
+                        "xref": []
+                    }
+                ],
+                "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 26, locStartCol = 1, locEndLine = 26, locEndCol = 10}",
+                "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 26, locStartCol = 11, locEndLine = 26, locEndCol = 12}",
+                "name": "X",
+                "struct_type": "EXCEPTION"
+            }
+        ],
         "typedefs": [
             {
-                "newtype": true,
-                "anns": {
-                    "loc_ann_list": [
-                        {
-                            "ann_tag": "hs.newtype",
-                            "ann_type": "SimpleAnn",
-                            "sep": {
-                                "sep_type": "NoSep"
-                            },
-                            "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 18, locEndLine = 34, locEndCol = 28}"
-                        }
-                    ],
-                    "loc_close": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 28, locEndLine = 34, locEndCol = 29}",
-                    "loc_open": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 17, locEndLine = 34, locEndCol = 18}"
-                },
                 "ann_type": {
                     "anns": null,
                     "loc": [
-                        "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 9, locEndLine = 34, locEndCol = 12}"
+                        "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 9, locEndLine = 7, locEndCol = 12}"
                     ],
                     "type": {
                         "type": "i64"
                     }
                 },
-                "xref": [],
-                "name": "Int",
-                "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 13, locEndLine = 34, locEndCol = 16}",
+                "anns": null,
+                "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 1, locEndLine = 7, locEndCol = 8}",
+                "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 7, locStartCol = 13, locEndLine = 7, locEndCol = 14}",
+                "name": "T",
+                "newtype": false,
                 "type": {
                     "type": "i64"
                 },
-                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 1, locEndLine = 34, locEndCol = 8}"
+                "xref": []
             }
         ],
-        "structs": [
+        "unions": [
             {
-                "name": "B",
-                "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
-                "struct_type": "STRUCT",
-                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 1, locEndLine = 3, locEndCol = 7}",
                 "fields": [
                     {
-                        "default_value": {
-                            "literal": {
-                                "value": 1,
-                                "type": "i16"
-                            }
-                        },
-                        "xref": [],
-                        "name": "a",
-                        "requiredness": "default",
                         "id": 1,
-                        "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 4, locStartCol = 10, locEndLine = 4, locEndCol = 11}",
-                        "type": {
-                            "type": "i16"
-                        }
-                    },
-                    {
-                        "xref": [],
-                        "name": "b",
-                        "requiredness": "default",
-                        "id": 2,
-                        "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 5, locStartCol = 10, locEndLine = 5, locEndCol = 11}",
-                        "type": {
-                            "type": "i32"
-                        }
-                    },
-                    {
-                        "xref": [],
-                        "name": "c",
-                        "requiredness": "default",
-                        "id": 3,
-                        "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 6, locStartCol = 10, locEndLine = 6, locEndCol = 11}",
-                        "type": {
-                            "type": "i64"
-                        }
-                    }
-                ]
-            },
-            {
-                "name": "C",
-                "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 9, locStartCol = 8, locEndLine = 9, locEndCol = 9}",
-                "struct_type": "STRUCT",
-                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 9, locStartCol = 1, locEndLine = 9, locEndCol = 7}",
-                "fields": [
-                    {
-                        "xref": [
-                            {
-                                "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
-                                "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 10, locStartCol = 11, locEndLine = 10, locEndCol = 17}"
-                            }
-                        ],
+                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 21, locStartCol = 11, locEndLine = 21, locEndCol = 12}",
                         "name": "x",
-                        "requiredness": "default",
-                        "id": 1,
-                        "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 10, locStartCol = 19, locEndLine = 10, locEndCol = 20}",
                         "type": {
-                            "inner_type": {
-                                "name": {
-                                    "name": "Number"
-                                },
-                                "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
-                                "type": "enum"
-                            },
-                            "type": "list"
+                            "type": "byte"
                         }
                     },
                     {
-                        "xref": [
-                            {
-                                "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 22, locStartCol = 6, locEndLine = 22, locEndCol = 19}",
-                                "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 11, locStartCol = 11, locEndLine = 11, locEndCol = 24}"
-                            }
-                        ],
-                        "name": "y",
-                        "requiredness": "default",
                         "id": 2,
-                        "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 11, locStartCol = 26, locEndLine = 11, locEndCol = 27}",
+                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 22, locStartCol = 19, locEndLine = 22, locEndCol = 20}",
+                        "name": "y",
                         "type": {
                             "inner_type": {
-                                "name": {
-                                    "name": "Number_Strict"
-                                },
-                                "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 22, locStartCol = 6, locEndLine = 22, locEndCol = 19}",
-                                "type": "enum"
+                                "type": "string"
                             },
                             "type": "list"
                         }
                     },
                     {
-                        "xref": [
-                            {
-                                "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
-                                "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 12, locStartCol = 6, locEndLine = 12, locEndCol = 7}"
-                            }
-                        ],
-                        "name": "z",
-                        "requiredness": "default",
                         "id": 3,
-                        "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 12, locStartCol = 8, locEndLine = 12, locEndCol = 9}",
+                        "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 23, locStartCol = 15, locEndLine = 23, locEndCol = 16}",
+                        "name": "z",
                         "type": {
-                            "name": {
-                                "name": "B"
+                            "inner_type": {
+                                "type": "i64"
                             },
-                            "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
-                            "type": "struct"
+                            "type": "set"
                         }
                     }
-                ]
+                ],
+                "loc_keyword": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 20, locStartCol = 1, locEndLine = 20, locEndCol = 6}",
+                "loc_name": "Loc {locFile = \"test/if/a.thrift\", locStartLine = 20, locStartCol = 7, locEndLine = 20, locEndCol = 8}",
+                "name": "U"
             }
-        ],
-        "path": "test/if/b.thrift",
-        "unions": [],
+        ]
+    },
+    {
         "consts": [
             {
-                "value": {
-                    "literal": {
-                        "value": 0,
-                        "type": "byte"
-                    }
-                },
                 "ann_type": {
                     "anns": null,
                     "loc": [
@@ -783,21 +623,21 @@
                         "type": "byte"
                     }
                 },
-                "xref": [],
-                "name": "byte_value",
+                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 37, locStartCol = 1, locEndLine = 37, locEndCol = 6}",
                 "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 37, locStartCol = 12, locEndLine = 37, locEndCol = 22}",
+                "name": "byte_value",
                 "type": {
                     "type": "byte"
                 },
-                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 37, locStartCol = 1, locEndLine = 37, locEndCol = 6}"
-            },
-            {
                 "value": {
                     "literal": {
-                        "value": 1,
-                        "type": "i16"
+                        "type": "byte",
+                        "value": 0
                     }
                 },
+                "xref": []
+            },
+            {
                 "ann_type": {
                     "anns": null,
                     "loc": [
@@ -807,21 +647,21 @@
                         "type": "i16"
                     }
                 },
-                "xref": [],
-                "name": "i16_value",
+                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 38, locStartCol = 1, locEndLine = 38, locEndCol = 6}",
                 "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 38, locStartCol = 11, locEndLine = 38, locEndCol = 20}",
+                "name": "i16_value",
                 "type": {
                     "type": "i16"
                 },
-                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 38, locStartCol = 1, locEndLine = 38, locEndCol = 6}"
-            },
-            {
                 "value": {
                     "literal": {
-                        "value": 2,
-                        "type": "i32"
+                        "type": "i16",
+                        "value": 1
                     }
                 },
+                "xref": []
+            },
+            {
                 "ann_type": {
                     "anns": null,
                     "loc": [
@@ -831,22 +671,21 @@
                         "type": "i32"
                     }
                 },
-                "xref": [],
-                "name": "i32_value",
+                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 39, locStartCol = 1, locEndLine = 39, locEndCol = 6}",
                 "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 39, locStartCol = 11, locEndLine = 39, locEndCol = 20}",
+                "name": "i32_value",
                 "type": {
                     "type": "i32"
                 },
-                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 39, locStartCol = 1, locEndLine = 39, locEndCol = 6}"
-            },
-            {
                 "value": {
                     "literal": {
-                        "string": "3",
-                        "value": 3,
-                        "type": "i64"
+                        "type": "i32",
+                        "value": 2
                     }
                 },
+                "xref": []
+            },
+            {
                 "ann_type": {
                     "anns": null,
                     "loc": [
@@ -856,22 +695,22 @@
                         "type": "i64"
                     }
                 },
-                "xref": [],
-                "name": "i64_value",
+                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 40, locStartCol = 1, locEndLine = 40, locEndCol = 6}",
                 "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 40, locStartCol = 11, locEndLine = 40, locEndCol = 20}",
+                "name": "i64_value",
                 "type": {
                     "type": "i64"
                 },
-                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 40, locStartCol = 1, locEndLine = 40, locEndCol = 6}"
-            },
-            {
                 "value": {
                     "literal": {
-                        "value": 0.5,
-                        "binary": "3f000000",
-                        "type": "float"
+                        "string": "3",
+                        "type": "i64",
+                        "value": 3
                     }
                 },
+                "xref": []
+            },
+            {
                 "ann_type": {
                     "anns": null,
                     "loc": [
@@ -881,22 +720,22 @@
                         "type": "float"
                     }
                 },
-                "xref": [],
-                "name": "float_value",
+                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 41, locStartCol = 1, locEndLine = 41, locEndCol = 6}",
                 "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 41, locStartCol = 13, locEndLine = 41, locEndCol = 24}",
+                "name": "float_value",
                 "type": {
                     "type": "float"
                 },
-                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 41, locStartCol = 1, locEndLine = 41, locEndCol = 6}"
-            },
-            {
                 "value": {
                     "literal": {
-                        "value": 3.14159,
-                        "binary": "400921f9f01b866e",
-                        "type": "double"
+                        "binary": "3f000000",
+                        "type": "float",
+                        "value": 0.5
                     }
                 },
+                "xref": []
+            },
+            {
                 "ann_type": {
                     "anns": null,
                     "loc": [
@@ -906,21 +745,22 @@
                         "type": "double"
                     }
                 },
-                "xref": [],
-                "name": "double_value",
+                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 42, locStartCol = 1, locEndLine = 42, locEndCol = 6}",
                 "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 42, locStartCol = 14, locEndLine = 42, locEndCol = 26}",
+                "name": "double_value",
                 "type": {
                     "type": "double"
                 },
-                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 42, locStartCol = 1, locEndLine = 42, locEndCol = 6}"
-            },
-            {
                 "value": {
                     "literal": {
-                        "value": true,
-                        "type": "bool"
+                        "binary": "400921f9f01b866e",
+                        "type": "double",
+                        "value": 3.14159
                     }
                 },
+                "xref": []
+            },
+            {
                 "ann_type": {
                     "anns": null,
                     "loc": [
@@ -930,21 +770,21 @@
                         "type": "bool"
                     }
                 },
-                "xref": [],
-                "name": "bool_value",
+                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 43, locStartCol = 1, locEndLine = 43, locEndCol = 6}",
                 "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 43, locStartCol = 12, locEndLine = 43, locEndCol = 22}",
+                "name": "bool_value",
                 "type": {
                     "type": "bool"
                 },
-                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 43, locStartCol = 1, locEndLine = 43, locEndCol = 6}"
-            },
-            {
                 "value": {
                     "literal": {
-                        "value": "xxx",
-                        "type": "string"
+                        "type": "bool",
+                        "value": true
                     }
                 },
+                "xref": []
+            },
+            {
                 "ann_type": {
                     "anns": null,
                     "loc": [
@@ -954,21 +794,21 @@
                         "type": "string"
                     }
                 },
-                "xref": [],
-                "name": "string_value",
+                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 44, locStartCol = 1, locEndLine = 44, locEndCol = 6}",
                 "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 44, locStartCol = 14, locEndLine = 44, locEndCol = 26}",
+                "name": "string_value",
                 "type": {
                     "type": "string"
                 },
-                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 44, locStartCol = 1, locEndLine = 44, locEndCol = 6}"
-            },
-            {
                 "value": {
                     "literal": {
-                        "value": "797979",
-                        "type": "binary"
+                        "type": "string",
+                        "value": "xxx"
                     }
                 },
+                "xref": []
+            },
+            {
                 "ann_type": {
                     "anns": null,
                     "loc": [
@@ -978,25 +818,21 @@
                         "type": "binary"
                     }
                 },
-                "xref": [],
-                "name": "binary_value",
+                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 45, locStartCol = 1, locEndLine = 45, locEndCol = 6}",
                 "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 45, locStartCol = 14, locEndLine = 45, locEndCol = 26}",
+                "name": "binary_value",
                 "type": {
                     "type": "binary"
                 },
-                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 45, locStartCol = 1, locEndLine = 45, locEndCol = 6}"
-            },
-            {
                 "value": {
                     "literal": {
-                        "value": {
-                            "string": "10",
-                            "value": 10,
-                            "type": "i64"
-                        },
-                        "type": "newtype"
+                        "type": "binary",
+                        "value": "797979"
                     }
                 },
+                "xref": []
+            },
+            {
                 "ann_type": {
                     "anns": null,
                     "loc": [
@@ -1006,46 +842,37 @@
                         "name": "Int"
                     }
                 },
-                "xref": [
-                    {
-                        "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 13, locEndLine = 34, locEndCol = 16}",
-                        "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 46, locStartCol = 7, locEndLine = 46, locEndCol = 10}"
-                    }
-                ],
-                "name": "newtype_value",
+                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 46, locStartCol = 1, locEndLine = 46, locEndCol = 6}",
                 "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 46, locStartCol = 11, locEndLine = 46, locEndCol = 24}",
+                "name": "newtype_value",
                 "type": {
                     "inner_type": {
                         "type": "i64"
                     },
+                    "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 13, locEndLine = 34, locEndCol = 16}",
                     "name": {
                         "name": "Int"
                     },
-                    "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 13, locEndLine = 34, locEndCol = 16}",
                     "type": "newtype"
                 },
-                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 46, locStartCol = 1, locEndLine = 46, locEndCol = 6}"
-            },
-            {
                 "value": {
                     "literal": {
-                        "value": [
-                            {
-                                "literal": {
-                                    "string": "0",
-                                    "value": 0,
-                                    "type": "i64"
-                                }
-                            },
-                            {
-                                "named_constant": {
-                                    "name": "i64_value"
-                                }
-                            }
-                        ],
-                        "type": "list"
+                        "type": "newtype",
+                        "value": {
+                            "string": "10",
+                            "type": "i64",
+                            "value": 10
+                        }
                     }
                 },
+                "xref": [
+                    {
+                        "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 46, locStartCol = 7, locEndLine = 46, locEndCol = 10}",
+                        "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 13, locEndLine = 34, locEndCol = 16}"
+                    }
+                ]
+            },
+            {
                 "ann_type": {
                     "anns": null,
                     "loc": [
@@ -1066,36 +893,37 @@
                         "type": "list"
                     }
                 },
-                "xref": [],
-                "name": "list_value",
+                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 49, locStartCol = 1, locEndLine = 49, locEndCol = 6}",
                 "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 49, locStartCol = 17, locEndLine = 49, locEndCol = 27}",
+                "name": "list_value",
                 "type": {
                     "inner_type": {
                         "type": "i64"
                     },
                     "type": "list"
                 },
-                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 49, locStartCol = 1, locEndLine = 49, locEndCol = 6}"
-            },
-            {
                 "value": {
                     "literal": {
+                        "type": "list",
                         "value": [
                             {
-                                "named_constant": {
-                                    "name": "string_value"
+                                "literal": {
+                                    "string": "0",
+                                    "type": "i64",
+                                    "value": 0
                                 }
                             },
                             {
-                                "literal": {
-                                    "value": "",
-                                    "type": "string"
+                                "named_constant": {
+                                    "name": "i64_value"
                                 }
                             }
-                        ],
-                        "type": "set"
+                        ]
                     }
                 },
+                "xref": []
+            },
+            {
                 "ann_type": {
                     "anns": null,
                     "loc": [
@@ -1116,55 +944,36 @@
                         "type": "set"
                     }
                 },
-                "xref": [],
-                "name": "set_value",
+                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 50, locStartCol = 1, locEndLine = 50, locEndCol = 6}",
                 "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 50, locStartCol = 19, locEndLine = 50, locEndCol = 28}",
+                "name": "set_value",
                 "type": {
                     "inner_type": {
                         "type": "string"
                     },
                     "type": "set"
                 },
-                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 50, locStartCol = 1, locEndLine = 50, locEndCol = 6}"
-            },
-            {
                 "value": {
                     "literal": {
+                        "type": "set",
                         "value": [
                             {
-                                "key": {
-                                    "literal": {
-                                        "string": "0",
-                                        "value": 0,
-                                        "type": "i64"
-                                    }
-                                },
-                                "val": {
-                                    "literal": {
-                                        "value": true,
-                                        "type": "bool"
-                                    }
+                                "named_constant": {
+                                    "name": "string_value"
                                 }
                             },
                             {
-                                "key": {
-                                    "literal": {
-                                        "string": "1",
-                                        "value": 1,
-                                        "type": "i64"
-                                    }
-                                },
-                                "val": {
-                                    "literal": {
-                                        "value": false,
-                                        "type": "bool"
-                                    }
+                                "literal": {
+                                    "type": "string",
+                                    "value": ""
                                 }
                             }
-                        ],
-                        "type": "map"
+                        ]
                     }
                 },
+                "xref": []
+            },
+            {
                 "ann_type": {
                     "anns": null,
                     "loc": [
@@ -1174,15 +983,6 @@
                         "Loc {locFile = \"test/if/b.thrift\", locStartLine = 53, locStartCol = 20, locEndLine = 53, locEndCol = 21}"
                     ],
                     "type": {
-                        "val_type": {
-                            "anns": null,
-                            "loc": [
-                                "Loc {locFile = \"test/if/b.thrift\", locStartLine = 53, locStartCol = 16, locEndLine = 53, locEndCol = 20}"
-                            ],
-                            "type": {
-                                "type": "bool"
-                            }
-                        },
                         "key_type": {
                             "anns": null,
                             "loc": [
@@ -1192,75 +992,86 @@
                                 "type": "i64"
                             }
                         },
-                        "type": "map"
+                        "type": "map",
+                        "val_type": {
+                            "anns": null,
+                            "loc": [
+                                "Loc {locFile = \"test/if/b.thrift\", locStartLine = 53, locStartCol = 16, locEndLine = 53, locEndCol = 20}"
+                            ],
+                            "type": {
+                                "type": "bool"
+                            }
+                        }
                     }
                 },
-                "xref": [],
-                "name": "map_value",
+                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 53, locStartCol = 1, locEndLine = 53, locEndCol = 6}",
                 "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 53, locStartCol = 22, locEndLine = 53, locEndCol = 31}",
+                "name": "map_value",
                 "type": {
-                    "val_type": {
-                        "type": "bool"
-                    },
                     "key_type": {
                         "type": "i64"
                     },
-                    "type": "map"
+                    "type": "map",
+                    "val_type": {
+                        "type": "bool"
+                    }
                 },
-                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 53, locStartCol = 1, locEndLine = 53, locEndCol = 6}"
-            },
-            {
                 "value": {
                     "literal": {
+                        "type": "map",
                         "value": [
                             {
                                 "key": {
                                     "literal": {
-                                        "value": "a",
-                                        "type": "string"
+                                        "string": "0",
+                                        "type": "i64",
+                                        "value": 0
                                     }
                                 },
                                 "val": {
                                     "literal": {
-                                        "value": "A",
-                                        "type": "string"
+                                        "type": "bool",
+                                        "value": true
                                     }
                                 }
                             },
                             {
                                 "key": {
                                     "literal": {
-                                        "value": "b",
-                                        "type": "string"
+                                        "string": "1",
+                                        "type": "i64",
+                                        "value": 1
                                     }
                                 },
                                 "val": {
                                     "literal": {
-                                        "value": "B",
-                                        "type": "string"
+                                        "type": "bool",
+                                        "value": false
                                     }
                                 }
                             }
-                        ],
-                        "type": "map"
+                        ]
                     }
                 },
+                "xref": []
+            },
+            {
                 "ann_type": {
                     "anns": {
                         "loc_ann_list": [
                             {
-                                "loc_val": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 54, locStartCol = 38, locEndLine = 54, locEndCol = 47}",
-                                "tag": "hs.type",
                                 "ann_type": "ValueAnn",
+                                "loc_equal": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 54, locStartCol = 36, locEndLine = 54, locEndCol = 37}",
+                                "loc_tag": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 54, locStartCol = 28, locEndLine = 54, locEndCol = 35}",
+                                "loc_val": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 54, locStartCol = 38, locEndLine = 54, locEndCol = 47}",
                                 "sep": {
                                     "sep_type": "NoSep"
                                 },
-                                "loc_tag": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 54, locStartCol = 28, locEndLine = 54, locEndCol = 35}",
-                                "loc_equal": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 54, locStartCol = 36, locEndLine = 54, locEndCol = 37}",
+                                "tag": "hs.type",
                                 "val": {
+                                    "ann_value_type": "TextAnn",
                                     "q": "DoubleQuote",
-                                    "t": "HashMap",
-                                    "ann_value_type": "TextAnn"
+                                    "t": "HashMap"
                                 }
                             }
                         ],
@@ -1274,15 +1085,6 @@
                         "Loc {locFile = \"test/if/b.thrift\", locStartLine = 54, locStartCol = 25, locEndLine = 54, locEndCol = 26}"
                     ],
                     "type": {
-                        "val_type": {
-                            "anns": null,
-                            "loc": [
-                                "Loc {locFile = \"test/if/b.thrift\", locStartLine = 54, locStartCol = 19, locEndLine = 54, locEndCol = 25}"
-                            ],
-                            "type": {
-                                "type": "string"
-                            }
-                        },
                         "key_type": {
                             "anns": null,
                             "loc": [
@@ -1292,68 +1094,68 @@
                                 "type": "string"
                             }
                         },
-                        "type": "map"
+                        "type": "map",
+                        "val_type": {
+                            "anns": null,
+                            "loc": [
+                                "Loc {locFile = \"test/if/b.thrift\", locStartLine = 54, locStartCol = 19, locEndLine = 54, locEndCol = 25}"
+                            ],
+                            "type": {
+                                "type": "string"
+                            }
+                        }
                     }
                 },
-                "xref": [],
-                "name": "hash_map_value",
+                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 54, locStartCol = 1, locEndLine = 54, locEndCol = 6}",
                 "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 55, locStartCol = 3, locEndLine = 55, locEndCol = 17}",
+                "name": "hash_map_value",
                 "type": {
-                    "val_type": {
-                        "type": "string"
-                    },
                     "key_type": {
                         "type": "string"
                     },
-                    "type": "map"
+                    "type": "map",
+                    "val_type": {
+                        "type": "string"
+                    }
                 },
-                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 54, locStartCol = 1, locEndLine = 54, locEndCol = 6}"
-            },
-            {
                 "value": {
                     "literal": {
+                        "type": "map",
                         "value": [
                             {
-                                "field_name": "a",
-                                "field_type": {
-                                    "type": "i16"
-                                },
-                                "field_value": {
+                                "key": {
                                     "literal": {
-                                        "value": 1,
-                                        "type": "i16"
+                                        "type": "string",
+                                        "value": "a"
+                                    }
+                                },
+                                "val": {
+                                    "literal": {
+                                        "type": "string",
+                                        "value": "A"
                                     }
                                 }
                             },
                             {
-                                "field_name": "b",
-                                "field_type": {
-                                    "type": "i32"
-                                },
-                                "field_value": {
+                                "key": {
                                     "literal": {
-                                        "value": 2,
-                                        "type": "i32"
+                                        "type": "string",
+                                        "value": "b"
                                     }
-                                }
-                            },
-                            {
-                                "field_name": "c",
-                                "field_type": {
-                                    "type": "i64"
                                 },
-                                "field_value": {
+                                "val": {
                                     "literal": {
-                                        "string": "3",
-                                        "value": 3,
-                                        "type": "i64"
+                                        "type": "string",
+                                        "value": "B"
                                     }
                                 }
                             }
-                        ],
-                        "type": "struct"
+                        ]
                     }
                 },
+                "xref": []
+            },
+            {
                 "ann_type": {
                     "anns": null,
                     "loc": [
@@ -1363,26 +1165,19 @@
                         "name": "B"
                     }
                 },
-                "xref": [
-                    {
-                        "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
-                        "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 57, locStartCol = 7, locEndLine = 57, locEndCol = 8}"
-                    }
-                ],
-                "name": "struct_value",
+                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 57, locStartCol = 1, locEndLine = 57, locEndCol = 6}",
                 "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 57, locStartCol = 9, locEndLine = 57, locEndCol = 21}",
+                "name": "struct_value",
                 "type": {
+                    "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
                     "name": {
                         "name": "B"
                     },
-                    "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
                     "type": "struct"
                 },
-                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 57, locStartCol = 1, locEndLine = 57, locEndCol = 6}"
-            },
-            {
                 "value": {
                     "literal": {
+                        "type": "struct",
                         "value": [
                             {
                                 "field_name": "a",
@@ -1391,8 +1186,8 @@
                                 },
                                 "field_value": {
                                     "literal": {
-                                        "value": 1,
-                                        "type": "i16"
+                                        "type": "i16",
+                                        "value": 1
                                     }
                                 }
                             },
@@ -1403,8 +1198,8 @@
                                 },
                                 "field_value": {
                                     "literal": {
-                                        "value": 2,
-                                        "type": "i32"
+                                        "type": "i32",
+                                        "value": 2
                                     }
                                 }
                             },
@@ -1416,15 +1211,22 @@
                                 "field_value": {
                                     "literal": {
                                         "string": "3",
-                                        "value": 3,
-                                        "type": "i64"
+                                        "type": "i64",
+                                        "value": 3
                                     }
                                 }
                             }
-                        ],
-                        "type": "struct"
+                        ]
                     }
                 },
+                "xref": [
+                    {
+                        "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 57, locStartCol = 7, locEndLine = 57, locEndCol = 8}",
+                        "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}"
+                    }
+                ]
+            },
+            {
                 "ann_type": {
                     "anns": null,
                     "loc": [
@@ -1434,43 +1236,107 @@
                         "name": "B"
                     }
                 },
-                "xref": [
-                    {
-                        "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
-                        "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 58, locStartCol = 7, locEndLine = 58, locEndCol = 8}"
-                    }
-                ],
-                "name": "explicit_struct_value",
+                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 58, locStartCol = 1, locEndLine = 58, locEndCol = 6}",
                 "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 58, locStartCol = 9, locEndLine = 58, locEndCol = 30}",
+                "name": "explicit_struct_value",
                 "type": {
+                    "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
                     "name": {
                         "name": "B"
                     },
-                    "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
                     "type": "struct"
                 },
-                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 58, locStartCol = 1, locEndLine = 58, locEndCol = 6}"
-            },
-            {
                 "value": {
                     "literal": {
+                        "type": "struct",
+                        "value": [
+                            {
+                                "field_name": "a",
+                                "field_type": {
+                                    "type": "i16"
+                                },
+                                "field_value": {
+                                    "literal": {
+                                        "type": "i16",
+                                        "value": 1
+                                    }
+                                }
+                            },
+                            {
+                                "field_name": "b",
+                                "field_type": {
+                                    "type": "i32"
+                                },
+                                "field_value": {
+                                    "literal": {
+                                        "type": "i32",
+                                        "value": 2
+                                    }
+                                }
+                            },
+                            {
+                                "field_name": "c",
+                                "field_type": {
+                                    "type": "i64"
+                                },
+                                "field_value": {
+                                    "literal": {
+                                        "string": "3",
+                                        "type": "i64",
+                                        "value": 3
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                "xref": [
+                    {
+                        "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 58, locStartCol = 7, locEndLine = 58, locEndCol = 8}",
+                        "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}"
+                    }
+                ]
+            },
+            {
+                "ann_type": {
+                    "anns": null,
+                    "loc": [
+                        "Loc {locFile = \"test/if/b.thrift\", locStartLine = 59, locStartCol = 7, locEndLine = 59, locEndCol = 8}"
+                    ],
+                    "type": {
+                        "name": "C"
+                    }
+                },
+                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 59, locStartCol = 1, locEndLine = 59, locEndCol = 6}",
+                "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 59, locStartCol = 9, locEndLine = 59, locEndCol = 37}",
+                "name": "explicit_nested_struct_value",
+                "type": {
+                    "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 9, locStartCol = 8, locEndLine = 9, locEndCol = 9}",
+                    "name": {
+                        "name": "C"
+                    },
+                    "type": "struct"
+                },
+                "value": {
+                    "literal": {
+                        "type": "struct",
                         "value": [
                             {
                                 "field_name": "x",
                                 "field_type": {
                                     "inner_type": {
+                                        "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
                                         "name": {
                                             "name": "Number"
                                         },
-                                        "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
                                         "type": "enum"
                                     },
                                     "type": "list"
                                 },
                                 "field_value": {
                                     "literal": {
-                                        "value": [],
-                                        "type": "list"
+                                        "type": "list",
+                                        "value": []
                                     }
                                 }
                             },
@@ -1478,32 +1344,33 @@
                                 "field_name": "y",
                                 "field_type": {
                                     "inner_type": {
+                                        "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 22, locStartCol = 6, locEndLine = 22, locEndCol = 19}",
                                         "name": {
                                             "name": "Number_Strict"
                                         },
-                                        "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 22, locStartCol = 6, locEndLine = 22, locEndCol = 19}",
                                         "type": "enum"
                                     },
                                     "type": "list"
                                 },
                                 "field_value": {
                                     "literal": {
-                                        "value": [],
-                                        "type": "list"
+                                        "type": "list",
+                                        "value": []
                                     }
                                 }
                             },
                             {
                                 "field_name": "z",
                                 "field_type": {
+                                    "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
                                     "name": {
                                         "name": "B"
                                     },
-                                    "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
                                     "type": "struct"
                                 },
                                 "field_value": {
                                     "literal": {
+                                        "type": "struct",
                                         "value": [
                                             {
                                                 "field_name": "a",
@@ -1512,8 +1379,8 @@
                                                 },
                                                 "field_value": {
                                                     "literal": {
-                                                        "value": 1,
-                                                        "type": "i16"
+                                                        "type": "i16",
+                                                        "value": 1
                                                     }
                                                 }
                                             },
@@ -1524,8 +1391,8 @@
                                                 },
                                                 "field_value": {
                                                     "literal": {
-                                                        "value": 2,
-                                                        "type": "i32"
+                                                        "type": "i32",
+                                                        "value": 2
                                                     }
                                                 }
                                             },
@@ -1537,124 +1404,257 @@
                                                 "field_value": {
                                                     "literal": {
                                                         "string": "3",
-                                                        "value": 3,
-                                                        "type": "i64"
+                                                        "type": "i64",
+                                                        "value": 3
                                                     }
                                                 }
                                             }
-                                        ],
-                                        "type": "struct"
+                                        ]
                                     }
                                 }
                             }
-                        ],
-                        "type": "struct"
-                    }
-                },
-                "ann_type": {
-                    "anns": null,
-                    "loc": [
-                        "Loc {locFile = \"test/if/b.thrift\", locStartLine = 59, locStartCol = 7, locEndLine = 59, locEndCol = 8}"
-                    ],
-                    "type": {
-                        "name": "C"
+                        ]
                     }
                 },
                 "xref": [
                     {
-                        "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 9, locStartCol = 8, locEndLine = 9, locEndCol = 9}",
-                        "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 59, locStartCol = 7, locEndLine = 59, locEndCol = 8}"
+                        "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 59, locStartCol = 7, locEndLine = 59, locEndCol = 8}",
+                        "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 9, locStartCol = 8, locEndLine = 9, locEndCol = 9}"
                     }
-                ],
-                "name": "explicit_nested_struct_value",
-                "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 59, locStartCol = 9, locEndLine = 59, locEndCol = 37}",
-                "type": {
-                    "name": {
-                        "name": "C"
-                    },
-                    "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 9, locStartCol = 8, locEndLine = 9, locEndCol = 9}",
-                    "type": "struct"
-                },
-                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 59, locStartCol = 1, locEndLine = 59, locEndCol = 6}"
+                ]
             }
         ],
-        "name": "b",
-        "includes": [],
         "enums": [
             {
-                "is_psuedo": false,
-                "name": "Number",
                 "constants": [
                     {
-                        "value": 0,
+                        "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 16, locStartCol = 3, locEndLine = 16, locEndCol = 7}",
                         "name": "Zero",
-                        "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 16, locStartCol = 3, locEndLine = 16, locEndCol = 7}"
+                        "value": 0
                     },
                     {
-                        "value": 1,
+                        "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 17, locStartCol = 3, locEndLine = 17, locEndCol = 6}",
                         "name": "One",
-                        "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 17, locStartCol = 3, locEndLine = 17, locEndCol = 6}"
+                        "value": 1
                     },
                     {
-                        "value": 2,
+                        "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 18, locStartCol = 3, locEndLine = 18, locEndCol = 6}",
                         "name": "Two",
-                        "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 18, locStartCol = 3, locEndLine = 18, locEndCol = 6}"
+                        "value": 2
                     },
                     {
-                        "value": 3,
+                        "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 19, locStartCol = 3, locEndLine = 19, locEndCol = 8}",
                         "name": "Three",
-                        "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 19, locStartCol = 3, locEndLine = 19, locEndCol = 8}"
+                        "value": 3
                     }
                 ],
+                "is_psuedo": false,
+                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 1, locEndLine = 15, locEndCol = 5}",
                 "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
-                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 1, locEndLine = 15, locEndCol = 5}"
+                "name": "Number"
             },
             {
-                "is_psuedo": false,
-                "name": "Number_Strict",
                 "constants": [
                     {
-                        "value": 0,
+                        "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 23, locStartCol = 3, locEndLine = 23, locEndCol = 7}",
                         "name": "Zero",
-                        "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 23, locStartCol = 3, locEndLine = 23, locEndCol = 7}"
+                        "value": 0
                     }
                 ],
+                "is_psuedo": false,
+                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 22, locStartCol = 1, locEndLine = 22, locEndCol = 5}",
                 "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 22, locStartCol = 6, locEndLine = 22, locEndCol = 19}",
-                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 22, locStartCol = 1, locEndLine = 22, locEndCol = 5}"
+                "name": "Number_Strict"
             },
             {
-                "is_psuedo": false,
-                "name": "Number_Discontinuous",
                 "constants": [
                     {
-                        "value": 5,
+                        "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 27, locStartCol = 3, locEndLine = 27, locEndCol = 7}",
                         "name": "Five",
-                        "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 27, locStartCol = 3, locEndLine = 27, locEndCol = 7}"
+                        "value": 5
                     },
                     {
-                        "value": 0,
+                        "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 28, locStartCol = 3, locEndLine = 28, locEndCol = 7}",
                         "name": "Zero",
-                        "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 28, locStartCol = 3, locEndLine = 28, locEndCol = 7}"
+                        "value": 0
                     }
                 ],
+                "is_psuedo": false,
+                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 26, locStartCol = 1, locEndLine = 26, locEndCol = 5}",
                 "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 26, locStartCol = 6, locEndLine = 26, locEndCol = 26}",
-                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 26, locStartCol = 1, locEndLine = 26, locEndCol = 5}"
+                "name": "Number_Discontinuous"
             },
             {
-                "is_psuedo": false,
-                "name": "Number_Empty",
                 "constants": [],
+                "is_psuedo": false,
+                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 31, locStartCol = 1, locEndLine = 31, locEndCol = 5}",
                 "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 31, locStartCol = 6, locEndLine = 31, locEndCol = 18}",
-                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 31, locStartCol = 1, locEndLine = 31, locEndCol = 5}"
+                "name": "Number_Empty"
             }
         ],
+        "includes": [],
+        "name": "b",
         "options": {
-            "path": "test/if/a.thrift",
-            "include_path": ".",
             "genfiles": null,
+            "include_path": ".",
             "out_path": "test/fixtures/gen-single-out-loc",
+            "path": "test/if/a.thrift",
             "recursive": true
         },
-        "services": []
+        "path": "test/if/b.thrift",
+        "services": [],
+        "structs": [
+            {
+                "fields": [
+                    {
+                        "default_value": {
+                            "literal": {
+                                "type": "i16",
+                                "value": 1
+                            }
+                        },
+                        "id": 1,
+                        "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 4, locStartCol = 10, locEndLine = 4, locEndCol = 11}",
+                        "name": "a",
+                        "requiredness": "default",
+                        "type": {
+                            "type": "i16"
+                        },
+                        "xref": []
+                    },
+                    {
+                        "id": 2,
+                        "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 5, locStartCol = 10, locEndLine = 5, locEndCol = 11}",
+                        "name": "b",
+                        "requiredness": "default",
+                        "type": {
+                            "type": "i32"
+                        },
+                        "xref": []
+                    },
+                    {
+                        "id": 3,
+                        "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 6, locStartCol = 10, locEndLine = 6, locEndCol = 11}",
+                        "name": "c",
+                        "requiredness": "default",
+                        "type": {
+                            "type": "i64"
+                        },
+                        "xref": []
+                    }
+                ],
+                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 1, locEndLine = 3, locEndCol = 7}",
+                "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
+                "name": "B",
+                "struct_type": "STRUCT"
+            },
+            {
+                "fields": [
+                    {
+                        "id": 1,
+                        "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 10, locStartCol = 19, locEndLine = 10, locEndCol = 20}",
+                        "name": "x",
+                        "requiredness": "default",
+                        "type": {
+                            "inner_type": {
+                                "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}",
+                                "name": {
+                                    "name": "Number"
+                                },
+                                "type": "enum"
+                            },
+                            "type": "list"
+                        },
+                        "xref": [
+                            {
+                                "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 10, locStartCol = 11, locEndLine = 10, locEndCol = 17}",
+                                "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 15, locStartCol = 6, locEndLine = 15, locEndCol = 12}"
+                            }
+                        ]
+                    },
+                    {
+                        "id": 2,
+                        "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 11, locStartCol = 26, locEndLine = 11, locEndCol = 27}",
+                        "name": "y",
+                        "requiredness": "default",
+                        "type": {
+                            "inner_type": {
+                                "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 22, locStartCol = 6, locEndLine = 22, locEndCol = 19}",
+                                "name": {
+                                    "name": "Number_Strict"
+                                },
+                                "type": "enum"
+                            },
+                            "type": "list"
+                        },
+                        "xref": [
+                            {
+                                "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 11, locStartCol = 11, locEndLine = 11, locEndCol = 24}",
+                                "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 22, locStartCol = 6, locEndLine = 22, locEndCol = 19}"
+                            }
+                        ]
+                    },
+                    {
+                        "id": 3,
+                        "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 12, locStartCol = 8, locEndLine = 12, locEndCol = 9}",
+                        "name": "z",
+                        "requiredness": "default",
+                        "type": {
+                            "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}",
+                            "name": {
+                                "name": "B"
+                            },
+                            "type": "struct"
+                        },
+                        "xref": [
+                            {
+                                "aLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 12, locStartCol = 6, locEndLine = 12, locEndCol = 7}",
+                                "rLoc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 3, locStartCol = 8, locEndLine = 3, locEndCol = 9}"
+                            }
+                        ]
+                    }
+                ],
+                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 9, locStartCol = 1, locEndLine = 9, locEndCol = 7}",
+                "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 9, locStartCol = 8, locEndLine = 9, locEndCol = 9}",
+                "name": "C",
+                "struct_type": "STRUCT"
+            }
+        ],
+        "typedefs": [
+            {
+                "ann_type": {
+                    "anns": null,
+                    "loc": [
+                        "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 9, locEndLine = 34, locEndCol = 12}"
+                    ],
+                    "type": {
+                        "type": "i64"
+                    }
+                },
+                "anns": {
+                    "loc_ann_list": [
+                        {
+                            "ann_tag": "hs.newtype",
+                            "ann_type": "SimpleAnn",
+                            "loc": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 18, locEndLine = 34, locEndCol = 28}",
+                            "sep": {
+                                "sep_type": "NoSep"
+                            }
+                        }
+                    ],
+                    "loc_close": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 28, locEndLine = 34, locEndCol = 29}",
+                    "loc_open": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 17, locEndLine = 34, locEndCol = 18}"
+                },
+                "loc_keyword": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 1, locEndLine = 34, locEndCol = 8}",
+                "loc_name": "Loc {locFile = \"test/if/b.thrift\", locStartLine = 34, locStartCol = 13, locEndLine = 34, locEndCol = 16}",
+                "name": "Int",
+                "newtype": true,
+                "type": {
+                    "type": "i64"
+                },
+                "xref": []
+            }
+        ],
+        "unions": []
     }
 ]

--- a/compiler/test/fixtures/gen-single-out/a.ast
+++ b/compiler/test/fixtures/gen-single-out/a.ast
@@ -1,194 +1,7 @@
 [
     {
-        "typedefs": [
-            {
-                "newtype": false,
-                "name": "T",
-                "type": {
-                    "type": "i64"
-                }
-            }
-        ],
-        "structs": [
-            {
-                "name": "A",
-                "struct_type": "STRUCT",
-                "fields": [
-                    {
-                        "default_value": {
-                            "named_constant": {
-                                "name": "a"
-                            }
-                        },
-                        "name": "a",
-                        "requiredness": "default",
-                        "id": 1,
-                        "type": {
-                            "inner_type": {
-                                "type": "i64"
-                            },
-                            "name": {
-                                "name": "T"
-                            },
-                            "type": "typedef"
-                        }
-                    },
-                    {
-                        "default_value": {
-                            "named_constant": {
-                                "name": "b"
-                            }
-                        },
-                        "name": "b",
-                        "requiredness": "default",
-                        "id": 2,
-                        "type": {
-                            "name": {
-                                "name": "B",
-                                "src": "b"
-                            },
-                            "type": "struct"
-                        }
-                    },
-                    {
-                        "default_value": {
-                            "named_constant": {
-                                "name": "bool_value",
-                                "src": "b"
-                            }
-                        },
-                        "name": "c",
-                        "requiredness": "default",
-                        "id": 3,
-                        "type": {
-                            "type": "bool"
-                        }
-                    },
-                    {
-                        "name": "d",
-                        "requiredness": "default",
-                        "id": 4,
-                        "type": {
-                            "inner_type": {
-                                "inner_type": {
-                                    "type": "i32"
-                                },
-                                "type": "list"
-                            },
-                            "type": "list"
-                        }
-                    },
-                    {
-                        "name": "e",
-                        "requiredness": "default",
-                        "id": 5,
-                        "type": {
-                            "val_type": {
-                                "type": "string"
-                            },
-                            "key_type": {
-                                "type": "i32"
-                            },
-                            "type": "map"
-                        }
-                    },
-                    {
-                        "default_value": {
-                            "literal": {
-                                "value": {
-                                    "name": "Two",
-                                    "src": "b"
-                                },
-                                "type": "enum"
-                            }
-                        },
-                        "name": "f",
-                        "requiredness": "default",
-                        "id": 6,
-                        "type": {
-                            "name": {
-                                "name": "Number",
-                                "src": "b"
-                            },
-                            "type": "enum"
-                        }
-                    },
-                    {
-                        "name": "g",
-                        "requiredness": "optional",
-                        "id": 7,
-                        "type": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "h",
-                        "requiredness": "required",
-                        "id": 8,
-                        "type": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            },
-            {
-                "name": "X",
-                "struct_type": "EXCEPTION",
-                "fields": [
-                    {
-                        "name": "reason",
-                        "requiredness": "default",
-                        "id": 1,
-                        "type": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
-        ],
-        "path": "test/if/a.thrift",
-        "unions": [
-            {
-                "name": "U",
-                "fields": [
-                    {
-                        "name": "x",
-                        "id": 1,
-                        "type": {
-                            "type": "byte"
-                        }
-                    },
-                    {
-                        "name": "y",
-                        "id": 2,
-                        "type": {
-                            "inner_type": {
-                                "type": "string"
-                            },
-                            "type": "list"
-                        }
-                    },
-                    {
-                        "name": "z",
-                        "id": 3,
-                        "type": {
-                            "inner_type": {
-                                "type": "i64"
-                            },
-                            "type": "set"
-                        }
-                    }
-                ]
-            }
-        ],
         "consts": [
             {
-                "value": {
-                    "named_constant": {
-                        "name": "i64_value",
-                        "src": "b"
-                    }
-                },
                 "name": "a",
                 "type": {
                     "inner_type": {
@@ -198,11 +11,25 @@
                         "name": "T"
                     },
                     "type": "typedef"
+                },
+                "value": {
+                    "named_constant": {
+                        "name": "i64_value",
+                        "src": "b"
+                    }
                 }
             },
             {
+                "name": "u",
+                "type": {
+                    "name": {
+                        "name": "U"
+                    },
+                    "type": "union"
+                },
                 "value": {
                     "literal": {
+                        "type": "union",
                         "value": {
                             "field_name": "y",
                             "field_type": {
@@ -213,6 +40,7 @@
                             },
                             "field_value": {
                                 "literal": {
+                                    "type": "list",
                                     "value": [
                                         {
                                             "named_constant": {
@@ -220,25 +48,25 @@
                                                 "src": "b"
                                             }
                                         }
-                                    ],
-                                    "type": "list"
+                                    ]
                                 }
                             }
-                        },
-                        "type": "union"
+                        }
                     }
-                },
-                "name": "u",
-                "type": {
-                    "name": {
-                        "name": "U"
-                    },
-                    "type": "union"
                 }
             },
             {
+                "name": "b",
+                "type": {
+                    "name": {
+                        "name": "B",
+                        "src": "b"
+                    },
+                    "type": "struct"
+                },
                 "value": {
                     "literal": {
+                        "type": "struct",
                         "value": [
                             {
                                 "field_name": "a",
@@ -276,22 +104,22 @@
                                     }
                                 }
                             }
-                        ],
-                        "type": "struct"
+                        ]
                     }
-                },
-                "name": "b",
+                }
+            },
+            {
+                "name": "default_d",
                 "type": {
                     "name": {
                         "name": "B",
                         "src": "b"
                     },
                     "type": "struct"
-                }
-            },
-            {
+                },
                 "value": {
                     "literal": {
+                        "type": "struct",
                         "value": [
                             {
                                 "field_name": "a",
@@ -320,29 +148,11 @@
                                     "default": null
                                 }
                             }
-                        ],
-                        "type": "struct"
+                        ]
                     }
-                },
-                "name": "default_d",
-                "type": {
-                    "name": {
-                        "name": "B",
-                        "src": "b"
-                    },
-                    "type": "struct"
                 }
             },
             {
-                "value": {
-                    "literal": {
-                        "value": {
-                            "name": "Zero",
-                            "src": "b"
-                        },
-                        "type": "enum"
-                    }
-                },
                 "name": "zero",
                 "type": {
                     "name": {
@@ -350,35 +160,46 @@
                         "src": "b"
                     },
                     "type": "enum"
+                },
+                "value": {
+                    "literal": {
+                        "type": "enum",
+                        "value": {
+                            "name": "Zero",
+                            "src": "b"
+                        }
+                    }
                 }
             }
         ],
-        "name": "a",
+        "enums": [],
         "includes": [
             "test/if/b.thrift"
         ],
-        "enums": [],
+        "name": "a",
         "options": {
-            "path": "test/if/a.thrift",
-            "include_path": ".",
             "genfiles": null,
+            "include_path": ".",
             "out_path": "test/fixtures/gen-single-out",
+            "path": "test/if/a.thrift",
             "recursive": true
         },
+        "path": "test/if/a.thrift",
         "services": [
             {
-                "name": "S",
                 "functions": [
                     {
                         "args": [
                             {
-                                "name": "x",
                                 "id": 1,
+                                "name": "x",
                                 "type": {
                                     "type": "i32"
                                 }
                             }
                         ],
+                        "name": "getNumber",
+                        "oneway": false,
                         "return_type": {
                             "name": {
                                 "name": "Number",
@@ -386,19 +207,19 @@
                             },
                             "type": "enum"
                         },
-                        "throws": [],
-                        "name": "getNumber",
-                        "oneway": false
+                        "throws": []
                     },
                     {
                         "args": [],
+                        "name": "doNothing",
+                        "oneway": false,
                         "return_type": {
                             "type": "void"
                         },
                         "throws": [
                             {
-                                "name": "ex",
                                 "id": 1,
+                                "name": "ex",
                                 "type": {
                                     "name": {
                                         "name": "X"
@@ -406,253 +227,328 @@
                                     "type": "exception"
                                 }
                             }
-                        ],
-                        "name": "doNothing",
-                        "oneway": false
+                        ]
                     }
-                ]
+                ],
+                "name": "S"
             },
             {
-                "name": "ParentService",
-                "functions": []
+                "functions": [],
+                "name": "ParentService"
             },
             {
-                "super": {
-                    "name": "ParentService"
-                },
-                "name": "ChildService",
                 "functions": [
                     {
                         "args": [],
+                        "name": "foo",
+                        "oneway": false,
                         "return_type": {
                             "type": "i32"
                         },
-                        "throws": [],
-                        "name": "foo",
-                        "oneway": false
+                        "throws": []
                     }
-                ]
-            }
-        ]
-    },
-    {
-        "typedefs": [
-            {
-                "newtype": true,
-                "name": "Int",
-                "type": {
-                    "type": "i64"
+                ],
+                "name": "ChildService",
+                "super": {
+                    "name": "ParentService"
                 }
             }
         ],
         "structs": [
             {
-                "name": "B",
-                "struct_type": "STRUCT",
                 "fields": [
                     {
                         "default_value": {
-                            "literal": {
-                                "value": 1,
-                                "type": "i16"
+                            "named_constant": {
+                                "name": "a"
                             }
                         },
+                        "id": 1,
                         "name": "a",
                         "requiredness": "default",
-                        "id": 1,
                         "type": {
-                            "type": "i16"
+                            "inner_type": {
+                                "type": "i64"
+                            },
+                            "name": {
+                                "name": "T"
+                            },
+                            "type": "typedef"
                         }
                     },
                     {
+                        "default_value": {
+                            "named_constant": {
+                                "name": "b"
+                            }
+                        },
+                        "id": 2,
                         "name": "b",
                         "requiredness": "default",
-                        "id": 2,
-                        "type": {
-                            "type": "i32"
-                        }
-                    },
-                    {
-                        "name": "c",
-                        "requiredness": "default",
-                        "id": 3,
-                        "type": {
-                            "type": "i64"
-                        }
-                    }
-                ]
-            },
-            {
-                "name": "C",
-                "struct_type": "STRUCT",
-                "fields": [
-                    {
-                        "name": "x",
-                        "requiredness": "default",
-                        "id": 1,
-                        "type": {
-                            "inner_type": {
-                                "name": {
-                                    "name": "Number"
-                                },
-                                "type": "enum"
-                            },
-                            "type": "list"
-                        }
-                    },
-                    {
-                        "name": "y",
-                        "requiredness": "default",
-                        "id": 2,
-                        "type": {
-                            "inner_type": {
-                                "name": {
-                                    "name": "Number_Strict"
-                                },
-                                "type": "enum"
-                            },
-                            "type": "list"
-                        }
-                    },
-                    {
-                        "name": "z",
-                        "requiredness": "default",
-                        "id": 3,
                         "type": {
                             "name": {
-                                "name": "B"
+                                "name": "B",
+                                "src": "b"
                             },
                             "type": "struct"
                         }
+                    },
+                    {
+                        "default_value": {
+                            "named_constant": {
+                                "name": "bool_value",
+                                "src": "b"
+                            }
+                        },
+                        "id": 3,
+                        "name": "c",
+                        "requiredness": "default",
+                        "type": {
+                            "type": "bool"
+                        }
+                    },
+                    {
+                        "id": 4,
+                        "name": "d",
+                        "requiredness": "default",
+                        "type": {
+                            "inner_type": {
+                                "inner_type": {
+                                    "type": "i32"
+                                },
+                                "type": "list"
+                            },
+                            "type": "list"
+                        }
+                    },
+                    {
+                        "id": 5,
+                        "name": "e",
+                        "requiredness": "default",
+                        "type": {
+                            "key_type": {
+                                "type": "i32"
+                            },
+                            "type": "map",
+                            "val_type": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "default_value": {
+                            "literal": {
+                                "type": "enum",
+                                "value": {
+                                    "name": "Two",
+                                    "src": "b"
+                                }
+                            }
+                        },
+                        "id": 6,
+                        "name": "f",
+                        "requiredness": "default",
+                        "type": {
+                            "name": {
+                                "name": "Number",
+                                "src": "b"
+                            },
+                            "type": "enum"
+                        }
+                    },
+                    {
+                        "id": 7,
+                        "name": "g",
+                        "requiredness": "optional",
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "id": 8,
+                        "name": "h",
+                        "requiredness": "required",
+                        "type": {
+                            "type": "string"
+                        }
                     }
-                ]
+                ],
+                "name": "A",
+                "struct_type": "STRUCT"
+            },
+            {
+                "fields": [
+                    {
+                        "id": 1,
+                        "name": "reason",
+                        "requiredness": "default",
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "name": "X",
+                "struct_type": "EXCEPTION"
             }
         ],
-        "path": "test/if/b.thrift",
-        "unions": [],
-        "consts": [
+        "typedefs": [
             {
-                "value": {
-                    "literal": {
-                        "value": 0,
-                        "type": "byte"
-                    }
-                },
-                "name": "byte_value",
-                "type": {
-                    "type": "byte"
-                }
-            },
-            {
-                "value": {
-                    "literal": {
-                        "value": 1,
-                        "type": "i16"
-                    }
-                },
-                "name": "i16_value",
-                "type": {
-                    "type": "i16"
-                }
-            },
-            {
-                "value": {
-                    "literal": {
-                        "value": 2,
-                        "type": "i32"
-                    }
-                },
-                "name": "i32_value",
-                "type": {
-                    "type": "i32"
-                }
-            },
-            {
-                "value": {
-                    "literal": {
-                        "string": "3",
-                        "value": 3,
-                        "type": "i64"
-                    }
-                },
-                "name": "i64_value",
+                "name": "T",
+                "newtype": false,
                 "type": {
                     "type": "i64"
                 }
-            },
+            }
+        ],
+        "unions": [
             {
+                "fields": [
+                    {
+                        "id": 1,
+                        "name": "x",
+                        "type": {
+                            "type": "byte"
+                        }
+                    },
+                    {
+                        "id": 2,
+                        "name": "y",
+                        "type": {
+                            "inner_type": {
+                                "type": "string"
+                            },
+                            "type": "list"
+                        }
+                    },
+                    {
+                        "id": 3,
+                        "name": "z",
+                        "type": {
+                            "inner_type": {
+                                "type": "i64"
+                            },
+                            "type": "set"
+                        }
+                    }
+                ],
+                "name": "U"
+            }
+        ]
+    },
+    {
+        "consts": [
+            {
+                "name": "byte_value",
+                "type": {
+                    "type": "byte"
+                },
                 "value": {
                     "literal": {
-                        "value": 0.5,
-                        "binary": "3f000000",
-                        "type": "float"
+                        "type": "byte",
+                        "value": 0
                     }
+                }
+            },
+            {
+                "name": "i16_value",
+                "type": {
+                    "type": "i16"
                 },
+                "value": {
+                    "literal": {
+                        "type": "i16",
+                        "value": 1
+                    }
+                }
+            },
+            {
+                "name": "i32_value",
+                "type": {
+                    "type": "i32"
+                },
+                "value": {
+                    "literal": {
+                        "type": "i32",
+                        "value": 2
+                    }
+                }
+            },
+            {
+                "name": "i64_value",
+                "type": {
+                    "type": "i64"
+                },
+                "value": {
+                    "literal": {
+                        "string": "3",
+                        "type": "i64",
+                        "value": 3
+                    }
+                }
+            },
+            {
                 "name": "float_value",
                 "type": {
                     "type": "float"
+                },
+                "value": {
+                    "literal": {
+                        "binary": "3f000000",
+                        "type": "float",
+                        "value": 0.5
+                    }
                 }
             },
             {
-                "value": {
-                    "literal": {
-                        "value": 3.14159,
-                        "binary": "400921f9f01b866e",
-                        "type": "double"
-                    }
-                },
                 "name": "double_value",
                 "type": {
                     "type": "double"
+                },
+                "value": {
+                    "literal": {
+                        "binary": "400921f9f01b866e",
+                        "type": "double",
+                        "value": 3.14159
+                    }
                 }
             },
             {
-                "value": {
-                    "literal": {
-                        "value": true,
-                        "type": "bool"
-                    }
-                },
                 "name": "bool_value",
                 "type": {
                     "type": "bool"
+                },
+                "value": {
+                    "literal": {
+                        "type": "bool",
+                        "value": true
+                    }
                 }
             },
             {
-                "value": {
-                    "literal": {
-                        "value": "xxx",
-                        "type": "string"
-                    }
-                },
                 "name": "string_value",
                 "type": {
                     "type": "string"
+                },
+                "value": {
+                    "literal": {
+                        "type": "string",
+                        "value": "xxx"
+                    }
                 }
             },
             {
-                "value": {
-                    "literal": {
-                        "value": "797979",
-                        "type": "binary"
-                    }
-                },
                 "name": "binary_value",
                 "type": {
                     "type": "binary"
+                },
+                "value": {
+                    "literal": {
+                        "type": "binary",
+                        "value": "797979"
+                    }
                 }
             },
             {
-                "value": {
-                    "literal": {
-                        "value": {
-                            "string": "10",
-                            "value": 10,
-                            "type": "i64"
-                        },
-                        "type": "newtype"
-                    }
-                },
                 "name": "newtype_value",
                 "type": {
                     "inner_type": {
@@ -662,17 +558,35 @@
                         "name": "Int"
                     },
                     "type": "newtype"
+                },
+                "value": {
+                    "literal": {
+                        "type": "newtype",
+                        "value": {
+                            "string": "10",
+                            "type": "i64",
+                            "value": 10
+                        }
+                    }
                 }
             },
             {
+                "name": "list_value",
+                "type": {
+                    "inner_type": {
+                        "type": "i64"
+                    },
+                    "type": "list"
+                },
                 "value": {
                     "literal": {
+                        "type": "list",
                         "value": [
                             {
                                 "literal": {
                                     "string": "0",
-                                    "value": 0,
-                                    "type": "i64"
+                                    "type": "i64",
+                                    "value": 0
                                 }
                             },
                             {
@@ -680,21 +594,21 @@
                                     "name": "i64_value"
                                 }
                             }
-                        ],
-                        "type": "list"
+                        ]
                     }
-                },
-                "name": "list_value",
-                "type": {
-                    "inner_type": {
-                        "type": "i64"
-                    },
-                    "type": "list"
                 }
             },
             {
+                "name": "set_value",
+                "type": {
+                    "inner_type": {
+                        "type": "string"
+                    },
+                    "type": "set"
+                },
                 "value": {
                     "literal": {
+                        "type": "set",
                         "value": [
                             {
                                 "named_constant": {
@@ -703,38 +617,41 @@
                             },
                             {
                                 "literal": {
-                                    "value": "",
-                                    "type": "string"
+                                    "type": "string",
+                                    "value": ""
                                 }
                             }
-                        ],
-                        "type": "set"
+                        ]
                     }
-                },
-                "name": "set_value",
-                "type": {
-                    "inner_type": {
-                        "type": "string"
-                    },
-                    "type": "set"
                 }
             },
             {
+                "name": "map_value",
+                "type": {
+                    "key_type": {
+                        "type": "i64"
+                    },
+                    "type": "map",
+                    "val_type": {
+                        "type": "bool"
+                    }
+                },
                 "value": {
                     "literal": {
+                        "type": "map",
                         "value": [
                             {
                                 "key": {
                                     "literal": {
                                         "string": "0",
-                                        "value": 0,
-                                        "type": "i64"
+                                        "type": "i64",
+                                        "value": 0
                                     }
                                 },
                                 "val": {
                                     "literal": {
-                                        "value": true,
-                                        "type": "bool"
+                                        "type": "bool",
+                                        "value": true
                                     }
                                 }
                             },
@@ -742,135 +659,79 @@
                                 "key": {
                                     "literal": {
                                         "string": "1",
-                                        "value": 1,
-                                        "type": "i64"
+                                        "type": "i64",
+                                        "value": 1
                                     }
                                 },
                                 "val": {
                                     "literal": {
-                                        "value": false,
-                                        "type": "bool"
+                                        "type": "bool",
+                                        "value": false
                                     }
                                 }
                             }
-                        ],
-                        "type": "map"
+                        ]
                     }
-                },
-                "name": "map_value",
-                "type": {
-                    "val_type": {
-                        "type": "bool"
-                    },
-                    "key_type": {
-                        "type": "i64"
-                    },
-                    "type": "map"
                 }
             },
             {
-                "value": {
-                    "literal": {
-                        "value": [
-                            {
-                                "key": {
-                                    "literal": {
-                                        "value": "a",
-                                        "type": "string"
-                                    }
-                                },
-                                "val": {
-                                    "literal": {
-                                        "value": "A",
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            {
-                                "key": {
-                                    "literal": {
-                                        "value": "b",
-                                        "type": "string"
-                                    }
-                                },
-                                "val": {
-                                    "literal": {
-                                        "value": "B",
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        ],
-                        "type": "map"
-                    }
-                },
                 "name": "hash_map_value",
                 "type": {
-                    "val_type": {
-                        "type": "string"
-                    },
                     "key_type": {
                         "type": "string"
                     },
-                    "type": "map"
-                }
-            },
-            {
+                    "type": "map",
+                    "val_type": {
+                        "type": "string"
+                    }
+                },
                 "value": {
                     "literal": {
+                        "type": "map",
                         "value": [
                             {
-                                "field_name": "a",
-                                "field_type": {
-                                    "type": "i16"
-                                },
-                                "field_value": {
+                                "key": {
                                     "literal": {
-                                        "value": 1,
-                                        "type": "i16"
+                                        "type": "string",
+                                        "value": "a"
+                                    }
+                                },
+                                "val": {
+                                    "literal": {
+                                        "type": "string",
+                                        "value": "A"
                                     }
                                 }
                             },
                             {
-                                "field_name": "b",
-                                "field_type": {
-                                    "type": "i32"
-                                },
-                                "field_value": {
+                                "key": {
                                     "literal": {
-                                        "value": 2,
-                                        "type": "i32"
+                                        "type": "string",
+                                        "value": "b"
                                     }
-                                }
-                            },
-                            {
-                                "field_name": "c",
-                                "field_type": {
-                                    "type": "i64"
                                 },
-                                "field_value": {
+                                "val": {
                                     "literal": {
-                                        "string": "3",
-                                        "value": 3,
-                                        "type": "i64"
+                                        "type": "string",
+                                        "value": "B"
                                     }
                                 }
                             }
-                        ],
-                        "type": "struct"
+                        ]
                     }
-                },
+                }
+            },
+            {
                 "name": "struct_value",
                 "type": {
                     "name": {
                         "name": "B"
                     },
                     "type": "struct"
-                }
-            },
-            {
+                },
                 "value": {
                     "literal": {
+                        "type": "struct",
                         "value": [
                             {
                                 "field_name": "a",
@@ -879,8 +740,8 @@
                                 },
                                 "field_value": {
                                     "literal": {
-                                        "value": 1,
-                                        "type": "i16"
+                                        "type": "i16",
+                                        "value": 1
                                     }
                                 }
                             },
@@ -891,8 +752,8 @@
                                 },
                                 "field_value": {
                                     "literal": {
-                                        "value": 2,
-                                        "type": "i32"
+                                        "type": "i32",
+                                        "value": 2
                                     }
                                 }
                             },
@@ -904,26 +765,79 @@
                                 "field_value": {
                                     "literal": {
                                         "string": "3",
-                                        "value": 3,
-                                        "type": "i64"
+                                        "type": "i64",
+                                        "value": 3
                                     }
                                 }
                             }
-                        ],
-                        "type": "struct"
+                        ]
                     }
-                },
+                }
+            },
+            {
                 "name": "explicit_struct_value",
                 "type": {
                     "name": {
                         "name": "B"
                     },
                     "type": "struct"
+                },
+                "value": {
+                    "literal": {
+                        "type": "struct",
+                        "value": [
+                            {
+                                "field_name": "a",
+                                "field_type": {
+                                    "type": "i16"
+                                },
+                                "field_value": {
+                                    "literal": {
+                                        "type": "i16",
+                                        "value": 1
+                                    }
+                                }
+                            },
+                            {
+                                "field_name": "b",
+                                "field_type": {
+                                    "type": "i32"
+                                },
+                                "field_value": {
+                                    "literal": {
+                                        "type": "i32",
+                                        "value": 2
+                                    }
+                                }
+                            },
+                            {
+                                "field_name": "c",
+                                "field_type": {
+                                    "type": "i64"
+                                },
+                                "field_value": {
+                                    "literal": {
+                                        "string": "3",
+                                        "type": "i64",
+                                        "value": 3
+                                    }
+                                }
+                            }
+                        ]
+                    }
                 }
             },
             {
+                "name": "explicit_nested_struct_value",
+                "type": {
+                    "name": {
+                        "name": "C"
+                    },
+                    "type": "struct"
+                },
                 "value": {
                     "literal": {
+                        "type": "struct",
                         "value": [
                             {
                                 "field_name": "x",
@@ -938,8 +852,8 @@
                                 },
                                 "field_value": {
                                     "literal": {
-                                        "value": [],
-                                        "type": "list"
+                                        "type": "list",
+                                        "value": []
                                     }
                                 }
                             },
@@ -956,8 +870,8 @@
                                 },
                                 "field_value": {
                                     "literal": {
-                                        "value": [],
-                                        "type": "list"
+                                        "type": "list",
+                                        "value": []
                                     }
                                 }
                             },
@@ -971,6 +885,7 @@
                                 },
                                 "field_value": {
                                     "literal": {
+                                        "type": "struct",
                                         "value": [
                                             {
                                                 "field_name": "a",
@@ -979,8 +894,8 @@
                                                 },
                                                 "field_value": {
                                                     "literal": {
-                                                        "value": 1,
-                                                        "type": "i16"
+                                                        "type": "i16",
+                                                        "value": 1
                                                     }
                                                 }
                                             },
@@ -991,8 +906,8 @@
                                                 },
                                                 "field_value": {
                                                     "literal": {
-                                                        "value": 2,
-                                                        "type": "i32"
+                                                        "type": "i32",
+                                                        "value": 2
                                                     }
                                                 }
                                             },
@@ -1004,91 +919,176 @@
                                                 "field_value": {
                                                     "literal": {
                                                         "string": "3",
-                                                        "value": 3,
-                                                        "type": "i64"
+                                                        "type": "i64",
+                                                        "value": 3
                                                     }
                                                 }
                                             }
-                                        ],
-                                        "type": "struct"
+                                        ]
                                     }
                                 }
                             }
-                        ],
-                        "type": "struct"
+                        ]
                     }
-                },
-                "name": "explicit_nested_struct_value",
-                "type": {
-                    "name": {
-                        "name": "C"
-                    },
-                    "type": "struct"
                 }
             }
         ],
-        "name": "b",
-        "includes": [],
         "enums": [
             {
-                "is_psuedo": false,
-                "name": "Number",
                 "constants": [
                     {
-                        "value": 0,
-                        "name": "Zero"
+                        "name": "Zero",
+                        "value": 0
                     },
                     {
-                        "value": 1,
-                        "name": "One"
+                        "name": "One",
+                        "value": 1
                     },
                     {
-                        "value": 2,
-                        "name": "Two"
+                        "name": "Two",
+                        "value": 2
                     },
                     {
-                        "value": 3,
-                        "name": "Three"
+                        "name": "Three",
+                        "value": 3
                     }
-                ]
+                ],
+                "is_psuedo": false,
+                "name": "Number"
             },
             {
-                "is_psuedo": false,
-                "name": "Number_Strict",
                 "constants": [
                     {
-                        "value": 0,
-                        "name": "Zero"
+                        "name": "Zero",
+                        "value": 0
                     }
-                ]
+                ],
+                "is_psuedo": false,
+                "name": "Number_Strict"
             },
             {
-                "is_psuedo": false,
-                "name": "Number_Discontinuous",
                 "constants": [
                     {
-                        "value": 5,
-                        "name": "Five"
+                        "name": "Five",
+                        "value": 5
                     },
                     {
-                        "value": 0,
-                        "name": "Zero"
+                        "name": "Zero",
+                        "value": 0
                     }
-                ]
+                ],
+                "is_psuedo": false,
+                "name": "Number_Discontinuous"
             },
             {
+                "constants": [],
                 "is_psuedo": false,
-                "name": "Number_Empty",
-                "constants": []
+                "name": "Number_Empty"
             }
         ],
+        "includes": [],
+        "name": "b",
         "options": {
-            "path": "test/if/a.thrift",
-            "include_path": ".",
             "genfiles": null,
+            "include_path": ".",
             "out_path": "test/fixtures/gen-single-out",
+            "path": "test/if/a.thrift",
             "recursive": true
         },
-        "services": []
+        "path": "test/if/b.thrift",
+        "services": [],
+        "structs": [
+            {
+                "fields": [
+                    {
+                        "default_value": {
+                            "literal": {
+                                "type": "i16",
+                                "value": 1
+                            }
+                        },
+                        "id": 1,
+                        "name": "a",
+                        "requiredness": "default",
+                        "type": {
+                            "type": "i16"
+                        }
+                    },
+                    {
+                        "id": 2,
+                        "name": "b",
+                        "requiredness": "default",
+                        "type": {
+                            "type": "i32"
+                        }
+                    },
+                    {
+                        "id": 3,
+                        "name": "c",
+                        "requiredness": "default",
+                        "type": {
+                            "type": "i64"
+                        }
+                    }
+                ],
+                "name": "B",
+                "struct_type": "STRUCT"
+            },
+            {
+                "fields": [
+                    {
+                        "id": 1,
+                        "name": "x",
+                        "requiredness": "default",
+                        "type": {
+                            "inner_type": {
+                                "name": {
+                                    "name": "Number"
+                                },
+                                "type": "enum"
+                            },
+                            "type": "list"
+                        }
+                    },
+                    {
+                        "id": 2,
+                        "name": "y",
+                        "requiredness": "default",
+                        "type": {
+                            "inner_type": {
+                                "name": {
+                                    "name": "Number_Strict"
+                                },
+                                "type": "enum"
+                            },
+                            "type": "list"
+                        }
+                    },
+                    {
+                        "id": 3,
+                        "name": "z",
+                        "requiredness": "default",
+                        "type": {
+                            "name": {
+                                "name": "B"
+                            },
+                            "type": "struct"
+                        }
+                    }
+                ],
+                "name": "C",
+                "struct_type": "STRUCT"
+            }
+        ],
+        "typedefs": [
+            {
+                "name": "Int",
+                "newtype": true,
+                "type": {
+                    "type": "i64"
+                }
+            }
+        ],
+        "unions": []
     }
 ]


### PR DESCRIPTION
Summary:
The ordering of keys changed due to a hash function change in hashable
1.3.1, which broke the tests here.

This diff changes the JSON output to sort the keys deterministically.

Differential Revision: D27363566

