### PR TITLE
Fix package names

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -9,6 +9,6 @@ packages:
     compiler/thrift-compiler.cabal
     tests/thrift-tests.cabal
     haxl/thrift-haxl.cabal
-    cpp-channel/cpp-channel.cabal
+    cpp-channel/thrift-cpp-channel.cabal
 
 tests: true

--- a/ci-sdist.cabal.project
+++ b/ci-sdist.cabal.project
@@ -9,5 +9,5 @@ package thrift-lib
   flags: +tests_use_ipv4
 package thrift-server
   flags: +tests_use_ipv4
-package cpp-channel
+package thrift-cpp-channel
   flags: +tests_use_ipv4

--- a/ci.cabal.project
+++ b/ci.cabal.project
@@ -9,7 +9,7 @@ packages:
     server/thrift-server.cabal
     tests/thrift-tests.cabal
     haxl/thrift-haxl.cabal
-    cpp-channel/cpp-channel.cabal
+    cpp-channel/thrift-cpp-channel.cabal
 
 tests: true
 
@@ -20,5 +20,5 @@ package thrift-lib
   flags: +tests_use_ipv4
 package thrift-server
   flags: +tests_use_ipv4
-package cpp-channel
+package thrift-cpp-channel
   flags: +tests_use_ipv4


### PR DESCRIPTION
Summary: I renamed cpp-channel->thrift-cpp-channel, but missed a few places.

Differential Revision: D27734687

