### PR TITLE
thrift-lib: (publicly) expose Socket channel based server implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,10 @@ thrift-hs::
 		if/scoped_enums.thrift)
 	(cd tests && $(THRIFT_COMPILE) --hs \
 		if/service.thrift)
+	# those files are required for thrift-compiler's tests
+	mkdir -p compiler/tests/if
+	cp tests/if/*.thrift compiler/tests/if/
+	cp tests/if/*.hs compiler/tests/if/
 
 thrift-cpp::
 	mkdir -p cpp-channel/if cpp-channel/test/if

--- a/compiler/thrift-compiler.cabal
+++ b/compiler/thrift-compiler.cabal
@@ -18,6 +18,8 @@ extra-source-files:  CHANGELOG.md,
                      test/fixtures/**/*.ast,
                      test/fixtures/gen-hs2/**/*.hs,
                      test/if/*.thrift,
+                     tests/if/*.thrift,
+                     tests/if/*.hs
 
 description:
     A compiler from the Thrift Interface Definition Language (IDL) to Haskell.

--- a/lib/test/SocketChannelTest.hs
+++ b/lib/test/SocketChannelTest.hs
@@ -2,16 +2,17 @@
 
 module SocketChannelTest where
 
+import Network.Socket (maxListenQueue)
 import TestRunner
 import Test.HUnit hiding (State)
 
 import Thrift.Api
 import Thrift.Channel
+import Thrift.Channel.SocketChannel.Server
 import Thrift.Protocol.Id
 
 import Math.Calculator.Client
 
-import SocketServer
 import TestCommon
 
 main :: IO ()
@@ -35,4 +36,4 @@ mkClientTestSockWith
   -> Test
 mkClientTestSockWith lbl _opts action = TestLabel lbl $ TestCase $ do
   state <- initServerState
-  withServer binaryProtocolId (processCommand state) action
+  withServer binaryProtocolId Nothing maxListenQueue (processCommand state) action

--- a/lib/thrift-lib.cabal
+++ b/lib/thrift-lib.cabal
@@ -71,6 +71,7 @@ library
         Thrift.Codegen
         Thrift.Channel
         Thrift.Channel.SocketChannel
+        Thrift.Channel.SocketChannel.Server
         Thrift.Protocol
         Thrift.Protocol.Compact
         Thrift.Protocol.Id
@@ -105,6 +106,7 @@ library
         aeson-pretty,
         text-show,
         base >=4.11.1 && <4.15,
+        async ^>= 2.2,
         transformers ^>=0.5.5.0,
         bytestring ^>=0.10.8.2,
         network,
@@ -184,7 +186,6 @@ library test-lib
         Math.Calculator.Client
         Math.Adder.Service
         Math.Calculator.Service
-        SocketServer
         HsTest.Types
 
 common test-common


### PR DESCRIPTION
I have to admit some limited creativity regarding the names of all the functions in `Thrift.Channel.SocketChannel.Server`, I'm all ears if you have better suggestions.

(Getting CI to pass required adding back some copying logic for the compiler package, otherwise in the "testing isolated source distribution" scenario, it didn't have all the files it needs to run its tests. But it's now just part of the `thrift-hs` rule.)