### PR TITLE
Fix logging.cpp for open-source glog

### DIFF
--- a/common/util/cpp/logging.cpp
+++ b/common/util/cpp/logging.cpp
@@ -35,5 +35,9 @@ void glog_critical(const char* file, int line, const char* msg) noexcept {
 }
 
 void glog_flush() noexcept {
+#ifdef GLOG_VERBOSE
   google::FlushLogFiles(google::GLOG_VERBOSE);
+#else
+  google::FlushLogFiles(google::GLOG_INFO);
+#endif
 }


### PR DESCRIPTION
Summary:
Broken hsthrift open-source build: https://github.com/facebookincubator/hsthrift/runs/2467302419

```
cpp/logging.cpp:38:33: error:
     error: 'GLOG_VERBOSE' is not a member of 'google'; did you mean 'GLOG_ERROR'?
       38 |   google::FlushLogFiles(google::GLOG_VERBOSE);
          |                                 ^~~~~~~~~~~~
          |                                 GLOG_ERROR
   |
38 |   google::FlushLogFiles(google::GLOG_VERBOSE);
   |                                 ^
```

Differential Revision: D28217285

