### PR TITLE
Remove unnecessary dependency on libyarpl

### DIFF
--- a/cpp-channel/thrift-cpp-channel.cabal
+++ b/cpp-channel/thrift-cpp-channel.cabal
@@ -93,7 +93,6 @@ library
         thrift-core
         async
         wangle
-        yarpl
         fmt
         fizz
         stdc++


### PR DESCRIPTION
Summary: I don't know why CI passed without this change.

Differential Revision: D28255131

