### PR TITLE
Fix compiler bug for empty services

### DIFF
--- a/compiler/test/DummyBinaryForBuild.hs
+++ b/compiler/test/DummyBinaryForBuild.hs
@@ -1,0 +1,27 @@
+-- Copyright 2004-present Facebook. All Rights Reserved.
+{-# OPTIONS_GHC -fno-warn-unused-imports#-}
+
+module DummyBinaryForBuild
+  ( main
+  ) where
+
+import A.Types
+import A.S.Client
+import A.S.Service
+import A.ChildService.Client
+import A.ChildService.Service
+import A.ParentService.Client
+import A.ParentService.Service
+
+import B.Types
+
+import C.Types
+import C.MyService.Client
+import C.MyService.Service
+
+import D.Types
+
+-- Create an empty binary to be used as a build target that depends on the
+-- compiled Thrift (so that we can test that the generated Haskell compiles).
+main :: IO ()
+main = return ()

--- a/compiler/test/fixtures/gen-hs2/A/ParentService/Service.hs
+++ b/compiler/test/fixtures/gen-hs2/A/ParentService/Service.hs
@@ -12,7 +12,7 @@
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns#-}
 {-# LANGUAGE GADTs #-}
 module A.ParentService.Service
-       (ParentServiceCommand(..), reqName', reqParser', respWriter',
+       (ParentServiceCommand, reqName', reqParser', respWriter',
         onewayFunctions')
        where
 import qualified A.Types as Types


### PR DESCRIPTION
Summary:
The generated Haskell code for empty services would not compile due to trying to export the constructors of empty GADTs.

Fix this by not exporting the constructors for empty services — also remove the "where" from the data declarations for tidiness.

Also add a build target to test that these Thrift files compile properly now.

Reviewed By: watashi

Differential Revision: D29393825

