### PR TITLE
Take dependencies into account in the restore order

### DIFF
--- a/common/util/Util/Graph.hs
+++ b/common/util/Util/Graph.hs
@@ -1,0 +1,36 @@
+-- Copyright (c) Facebook, Inc. and its affiliates.
+
+module Util.Graph
+  ( postorder
+  ) where
+
+import Data.Hashable
+import qualified Data.HashSet as HashSet
+import qualified Data.HashMap.Strict as HashMap
+
+-- | Post-order traversal of a graph: guarantees that the dependents
+-- of a node occur before it in the result list, while as far as
+-- possible retaining the original order of the nodes.
+postorder
+  :: (Hashable vertex, Eq vertex)
+  => [node]
+    -- ^ Nodes in the order of traversal
+  -> (node -> vertex)
+    -- ^ Extract a hashable vertex from the node
+  -> (node -> [vertex])
+    -- ^ Out-edges from a node. Vertices that aren't in the set of
+    -- nodes are ignored.
+  -> [node]
+    -- ^ Result of post-order traversal
+postorder nodes vert out = go HashSet.empty nodes (\_ -> [])
+  where
+  m = HashMap.fromList [ (vert n, n) | n <- nodes ]
+
+  go seen [] cont = cont seen
+  go seen (n : nodes) cont
+    | v `HashSet.member` seen = go seen nodes cont
+    | otherwise = go (HashSet.insert v seen) deps
+       (\seen -> n : go seen nodes cont)
+    where
+      v = vert n
+      deps = [ n | v <- out n, Just n <- [HashMap.lookup v m] ]

--- a/common/util/fb-util.cabal
+++ b/common/util/fb-util.cabal
@@ -96,6 +96,7 @@ library
         Util.Fd
         Util.FilePath
         Util.Function
+        Util.Graph
         Util.GFlags
         Util.HSE
         Util.HUnit
@@ -350,6 +351,11 @@ test-suite list
   type: exitcode-stdio-1.0
   main-is: ListTest.hs
   ghc-options: -main-is ListTest
+test-suite graph
+  import: fb-haskell, test-common
+  type: exitcode-stdio-1.0
+  main-is: GraphTest.hs
+  ghc-options: -main-is GraphTest
 test-suite concurrent
   import: fb-haskell, test-common
   type: exitcode-stdio-1.0

--- a/common/util/tests/GraphTest.hs
+++ b/common/util/tests/GraphTest.hs
@@ -1,0 +1,43 @@
+-- Copyright (c) Facebook, Inc. and its affiliates.
+
+module GraphTest (main) where
+
+import Control.Monad
+import qualified Data.IntMap as IntMap
+import Data.Maybe
+
+import Test.QuickCheck
+import Test.HUnit
+import TestRunner
+import Util.Graph
+
+main :: IO ()
+main = testRunner $ TestList
+  [ TestLabel "postorder" $ TestCase $ do
+      result <- quickCheckResult prop_postorder
+      case result of
+        Success{} -> return ()
+        _ -> assertFailure "failed"
+  ]
+
+prop_postorder :: Property
+prop_postorder = do
+  forAll graphs $ \(nodes, outMap) ->
+    check nodes outMap && check (reverse nodes) outMap
+    -- regardless of the input order of the nodes, dependencies should
+    -- appear before dependents in the output.
+  where
+  check nodes outMap =
+    and [ posOf o < posOf n | n <- nodes, o <- out n ]
+    where
+      out n = fromJust (IntMap.lookup n outMap)
+      order = postorder nodes id out
+      pos = IntMap.fromList (zip order [(0::Int)..])
+      posOf n = fromJust (IntMap.lookup n pos)
+
+  graphs = do
+    NonNegative numNodes <- arbitrary
+    edges <- forM [1..numNodes] $ \n -> do
+      outs <- sublistOf [1..n-1] -- only earlier nodes, so we get no cycles
+      return (n,outs)
+    return ([1..numNodes], IntMap.fromList edges)


### PR DESCRIPTION
Summary: Restore a DB's dependencies first, if they need restoring.

Reviewed By: zsol

Differential Revision: D29634751

