### PR TITLE
Permit building on aarch64 (e.g. M1)

### DIFF
--- a/common/util/fb-util.cabal
+++ b/common/util/fb-util.cabal
@@ -60,9 +60,7 @@ common fb-haskell
 
 common fb-cpp
   cxx-options: -std=c++17
-  if arch(aarch64)
-     cxx-options: -march=native
-  else
+  if arch(x86_64)
      cxx-options: -march=haswell
   if flag(opt)
      cxx-options: -O3

--- a/common/util/fb-util.cabal
+++ b/common/util/fb-util.cabal
@@ -59,7 +59,11 @@ common fb-haskell
      ghc-options: -O2
 
 common fb-cpp
-  cxx-options: -std=c++17 -march=haswell
+  cxx-options: -std=c++17
+  if arch(aarch64)
+     cxx-options: -march=native
+  else
+     cxx-options: -march=haswell
   if flag(opt)
      cxx-options: -O3
 

--- a/cpp-channel/thrift-cpp-channel.cabal
+++ b/cpp-channel/thrift-cpp-channel.cabal
@@ -67,9 +67,7 @@ common fb-haskell
 
 common fb-cpp
   cxx-options: -std=c++17
-  if arch(aarch64)
-     cxx-options: -march=native
-  else
+  if arch(x86_64)
      cxx-options: -march=haswell
   if flag(opt)
      cxx-options: -O3

--- a/cpp-channel/thrift-cpp-channel.cabal
+++ b/cpp-channel/thrift-cpp-channel.cabal
@@ -66,7 +66,11 @@ common fb-haskell
      ghc-options: -O2
 
 common fb-cpp
-  cxx-options: -std=c++17 -march=haswell
+  cxx-options: -std=c++17
+  if arch(aarch64)
+     cxx-options: -march=native
+  else
+     cxx-options: -march=haswell
   if flag(opt)
      cxx-options: -O3
 

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -25,9 +25,7 @@ BUILD_SUBDIR=_build
 # In Glean we use some AVX2 intrinsics, so we have to pick a compatible
 # architecture here for compiling folly.
 arch=$(uname -m)
-if [ "$arch" == aarch64 ] ; then
-	export CXXFLAGS=-march=native
-else
+if [ "$arch" == x86_64 ] ; then
 	export CXXFLAGS=-march=corei7
 fi
 

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -24,7 +24,12 @@ BUILD_SUBDIR=_build
 #   folly/container/detail/F14IntrinsicsAvailability.h
 # In Glean we use some AVX2 intrinsics, so we have to pick a compatible
 # architecture here for compiling folly.
-export CXXFLAGS=-march=corei7
+arch=$(uname -m)
+if [ "$arch" == aarch64 ] ; then
+	export CXXFLAGS=-march=native
+else
+	export CXXFLAGS=-march=corei7
+fi
 
 while [ "$#" -gt 0 ]; do
     case "$1" in

--- a/server/thrift-server.cabal
+++ b/server/thrift-server.cabal
@@ -61,7 +61,11 @@ common fb-haskell
      ghc-options: -O2
 
 common fb-cpp
-  cxx-options: -std=c++17 -march=haswell
+  cxx-options: -std=c++17
+  if arch(aarch64)
+     cxx-options: -march=native
+  else
+     cxx-options: -march=haswell
   if flag(opt)
      cxx-options: -O3
 

--- a/server/thrift-server.cabal
+++ b/server/thrift-server.cabal
@@ -62,9 +62,7 @@ common fb-haskell
 
 common fb-cpp
   cxx-options: -std=c++17
-  if arch(aarch64)
-     cxx-options: -march=native
-  else
+  if arch(x86_64)
      cxx-options: -march=haswell
   if flag(opt)
      cxx-options: -O3


### PR DESCRIPTION
Lets hsthrift and deps build on aarch64 (e.g. Debian on Macbook w/ M1)