### PR TITLE
Add arm64/aarch64 Dockerfile example

### DIFF
--- a/.github/workflows/Dockerfile.arm64v8
+++ b/.github/workflows/Dockerfile.arm64v8
@@ -1,0 +1,45 @@
+#
+# This produces an image that can be used to build on arm64/aarch64
+#
+FROM arm64v8/ubuntu:20.04
+ENV TZ=Europe/London
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+RUN apt-get update
+RUN apt-get install -y \
+    g++ \
+    cmake \
+    bison flex \
+    git cmake \
+    libzstd-dev \
+    libboost-all-dev \
+    libevent-dev \
+    libdouble-conversion-dev \
+    libgoogle-glog-dev \
+    libgflags-dev \
+    libiberty-dev \
+    liblz4-dev \
+    liblzma-dev \
+    libsnappy-dev \
+    make \
+    zlib1g-dev \
+    binutils-dev \
+    libjemalloc-dev \
+    libssl-dev \
+    pkg-config \
+    libunwind-dev \
+    libsodium-dev \
+    curl \
+    libpcre3-dev \
+    libmysqlclient-dev \
+    libfftw3-dev \
+    libfmt-dev \
+    libgmp-dev \
+    libtinfo-dev
+
+# install ghcup
+ARG GHCUP_VERSION=0.1.17.4
+RUN curl --proto '=https' --tlsv1.2 -sSf https://downloads.haskell.org/~ghcup/$GHCUP_VERSION/aarch64-linux-ghcup-$GHCUP_VERSION > /usr/bin/ghcup && \
+    chmod +x /usr/bin/ghcup
+
+ENV PATH=/root/.ghcup/bin:$PATH
+ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH


### PR DESCRIPTION
Example of how to build a working hsthrift or Glean image for arm. This
is useful if you're running on M1 or other arm hardware.

To build:
> docker buildx build --file=Dockerfile.arm64v8 --push -t mytag .

Testing: run the image and you should have a basic aarch64 machine with ghcup

```
$ uname -msr
Linux 5.10.76-linuxkit aarch64

$ which ghcup
/usr/bin/ghcup
```