### PR TITLE
Support hsthrift getdeps.py build flavor as sub-package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,8 @@ jobs:
         run: echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
       - name: Populate hackage index
         run: cabal update
+      - name: Install ninja
+        run: apt install ninja-build
       - name: Install folly, fizz, wangle, fbthrift
         run: ./new_install_deps.sh
       - name: Build all targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,5 @@ jobs:
         run: ./build.sh build --allow-system-packages --only-deps --install-prefix="$HOME/.hsthrift" hsthrift
       - name: Build all targets
         run: make all BUILD_DEPS=1 INSTALL_PREFIX="$HOME/.hsthrift"
-      - name: Install libfmt
-        run: apt-get install -y libfmt-dev
-      - name: Run testsuites
-        run: make test BUILD_DEPS=1 INSTALL_PREFIX="$HOME/.hsthrift"
+          #      - name: Run testsuites
+          #        run: make test BUILD_DEPS=1 INSTALL_PREFIX="$HOME/.hsthrift"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,5 +73,7 @@ jobs:
         run: ./build.sh build --allow-system-packages --only-deps --install-prefix="$HOME/.hsthrift" hsthrift
       - name: Build all targets
         run: make all BUILD_DEPS=1 INSTALL_PREFIX="$HOME/.hsthrift"
+      - name: Install libfmt
+        run: apt-get install -y libfmt-dev
       - name: Run testsuites
         run: make test BUILD_DEPS=1 INSTALL_PREFIX="$HOME/.hsthrift"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,30 @@ jobs:
       - name: Run testsuites
         run: cabal test mangle fb-util thrift-compiler thrift-lib thrift-cpp-channel thrift-server thrift-tests --keep-going
         working-directory: ./_sdists
+  # check we can build the nosudo way
+  ci-nosudo:
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: [8.10.7]
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/facebookincubator/hsthrift/ci-base:ghcup
+      options: --cpus 2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install ${{ matrix.ghc }}
+        run: ghcup install ghc ${{ matrix.ghc }} --set
+      - name: Install cabal-install-3.6
+        run: ghcup install cabal -u https://downloads.haskell.org/~cabal/cabal-install-3.6.0.0/cabal-install-3.6.0.0-x86_64-linux.tar.xz 3.6.0.0 --set
+      - name: Add GHC and cabal to PATH
+        run: echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
+      - name: Populate hackage index
+        run: cabal update
+      - name: Install folly, fizz, wangle, fbthrift etc
+        run: ./build.sh build --allow-system-packages --only-deps --install-prefix="$HOME/.hsthrift" hsthrift
+      - name: Build all targets
+        run: make all BUILD_DEPS=1 INSTALL_PREFIX="$HOME/.hsthrift"
+      - name: Run testsuites
+        run: make test BUILD_DEPS=1 INSTALL_PREFIX="$HOME/.hsthrift"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,9 @@ jobs:
         run: echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
       - name: Populate hackage index
         run: cabal update
-      - name: Install folly, fizz, wangle, fbthrift etc
-        run: ./build.sh build --allow-system-packages --only-deps --install-prefix="$HOME/.hsthrift" hsthrift
+      - name: Install folly, fizz, wangle, fbthrift
+        run: ./new_install_deps.sh
       - name: Build all targets
-        run: make all BUILD_DEPS=1 INSTALL_PREFIX="$HOME/.hsthrift"
-          #      - name: Run testsuites
-          #        run: make test BUILD_DEPS=1 INSTALL_PREFIX="$HOME/.hsthrift"
+        run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" PATH="$PATH:$HOME/.hsthrift/bin" make all
+      - name: Run testsuites
+        run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" PATH="$PATH:$HOME/.hsthrift/bin" make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,4 +74,4 @@ jobs:
       - name: Build all targets
         run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" PATH="$PATH:$HOME/.hsthrift/bin" make all
       - name: Run testsuites
-        run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" PATH="$PATH:$HOME/.hsthrift/bin" make test
+        run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" PATH="$PATH:$HOME/.hsthrift/bin" cabal test mangle fb-util thrift-compiler thrift-lib thrift-server thrift-tests --keep-going

--- a/Makefile
+++ b/Makefile
@@ -4,36 +4,8 @@
 
 CABAL_BIN := cabal
 
-ifeq ($(BUILD_DEPS),1)
-    empty :=
-    space := $(empty) $(empty)
-
-    # set to install deps into e.g. $HOME/.glean
-    ifdef INSTALL_PREFIX
-        BUILDER := ./build.sh --install-prefix=$(INSTALL_PREFIX)
-    else
-        BUILDER := ./build.sh
-    endif
-
-    DEPS_INSTALLDIR := $(patsubst %/hsthrift,%,\
-        $(shell $(BUILDER) show-inst-dir hsthrift))
-    DEPS := $(shell $(BUILDER) show-inst-dir hsthrift --recursive)
-    LIBDIRS := $(patsubst %,--extra-lib-dirs=%/lib,$(DEPS))
-    INCLUDEDIRS := $(patsubst %,--extra-include-dirs=%/include,$(DEPS))
-    PKG_CONFIG_PATH := $(subst $(space),:,\
-                $(shell find $(DEPS_INSTALLDIR) -name pkgconfig -type d))
-    LD_LIBRARY_PATH := $(subst $(space),:,$(patsubst %,%/lib,$(DEPS)))
-
-    THRIFT1 := $(patsubst %,%/bin/thrift1,\
-                $(shell $(BUILDER) show-inst-dir fbthrift))
-
-    CABAL=env PKG_CONFIG_PATH="$(PKG_CONFIG_PATH)" \
-          LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" \
-          $(CABAL_BIN) $(LIBDIRS) $(INCLUDEDIRS) $(CABAL_PROJECT)
-else
-    THRIFT1 := thrift1
-    CABAL := $(CABAL_BIN)
-endif
+THRIFT1 := thrift1
+CABAL := $(CABAL_BIN)
 
 all:: compiler thrift-hs thrift-cpp server
 
@@ -146,8 +118,3 @@ thrift-cpp::
 	cd tests/if && $(THRIFT1) -I . --gen mstch_cpp2 \
 		-o . \
 		hs_test.thrift
-
-# convenient BUILD_DEPS=1 wrapper over cabal
-.PHONY: test
-test: all
-	$(CABAL) test all

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,32 @@
 # These are a few rules to help build the open-source hsthrift. This
 # file will hopefully go away in due course.
+#
+
+CABAL_BIN := cabal
 
 ifeq ($(BUILD_DEPS),1)
 	empty :=
 	space := $(empty) $(empty)
 	BUILDER := ./build.sh
 
+	DEPS_INSTALLDIR := $(patsubst %/hsthrift,%,\
+		$(shell $(BUILDER) show-inst-dir hsthrift))
 	DEPS := $(shell $(BUILDER) show-inst-dir hsthrift --recursive)
 	LIBDIRS := $(patsubst %,--extra-lib-dirs=%/lib,$(DEPS))
 	INCLUDEDIRS := $(patsubst %,--extra-include-dirs=%/include,$(DEPS))
-	PKG_CONFIG_PATH := $(subst $(space),:,$(shell find $(DEPS) -name pkgconfig -type d))
+	PKG_CONFIG_PATH := $(subst $(space),:,\
+                $(shell find $(DEPS_INSTALLDIR) -name pkgconfig -type d))
 	LD_LIBRARY_PATH := $(subst $(space),:,$(patsubst %,%/lib,$(DEPS)))
 
-	THRIFT1 := $(patsubst %,%/bin/thrift1,$(shell $(BUILDER) show-inst-dir fbthrift))
+	THRIFT1 := $(patsubst %,%/bin/thrift1,\
+                $(shell $(BUILDER) show-inst-dir fbthrift))
 
-	CABAL=env PKG_CONFIG_PATH="$(PKG_CONFIG_PATH)" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" cabal $(LIBDIRS) $(INCLUDEDIRS)
+	CABAL=env PKG_CONFIG_PATH="$(PKG_CONFIG_PATH)" \
+              LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" \
+              $(CABAL_BIN) $(LIBDIRS) $(INCLUDEDIRS)
 else
 	THRIFT1 := thrift1
-	CABAL := cabal
+	CABAL := $(CABAL_BIN)
 endif
 
 all:: compiler thrift-hs thrift-cpp server
@@ -131,3 +140,8 @@ thrift-cpp::
 	cd tests/if && $(THRIFT1) -I . --gen mstch_cpp2 \
 		-o . \
 		hs_test.thrift
+
+# convenient BUILD_DEPS=1 wrapper over cabal
+.PHONY: test
+test: all
+	$(CABAL) test all

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ ifeq ($(BUILD_DEPS),1)
 
 	CABAL=env PKG_CONFIG_PATH="$(PKG_CONFIG_PATH)" \
               LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" \
-              $(CABAL_BIN) $(LIBDIRS) $(INCLUDEDIRS)
+              $(CABAL_BIN) $(LIBDIRS) $(INCLUDEDIRS) $(CABAL_PROJECT)
 else
 	THRIFT1 := thrift1
 	CABAL := $(CABAL_BIN)

--- a/README.md
+++ b/README.md
@@ -188,14 +188,14 @@ recent tag and update all the repos to the same tag.
 Support for building hsthrift with the Meta getdeps.py tool is available. This
 avoids the need for sudo access to install folly and other dependencies.
 
-You should have installed:
+You should have installed the libraries mentioned above, as well as:
 ```
 apt install  \
     ninja-build \
     cmake
 ```
 
-Then build and install the hsthrift source dependencies:
+Now build and install the hsthrift source dependencies:
 ```
 ./new_install_deps.sh
 
@@ -214,5 +214,5 @@ make all
 
 and test the installation with:
 ```
-make test
+cabal test all
 ```

--- a/README.md
+++ b/README.md
@@ -188,18 +188,31 @@ recent tag and update all the repos to the same tag.
 Support for building hsthrift with the Meta getdeps.py tool is available. This
 avoids the need for sudo access to install folly and other dependencies.
 
-To build and install the hsthrift dependencies:
+You should have installed:
 ```
-./build.sh build --allow-system-packages --only-deps hsthrift
+apt install  \
+    ninja-build \
+    cmake
 ```
 
-You can then build hsthrift with `make` as follows:
+Then build and install the hsthrift source dependencies:
+```
+./new_install_deps.sh
 
 ```
-make all BUILD_DEPS=1
+
+Set your env variables to pick up the new libraries and binaries:
+```
+export LD_LIBRARY_PATH=$HOME/.hsthrift/lib:
+export PKG_CONFIG_PATH=$HOME/.hsthrift/lib/pkgconfig
+export PATH=$PATH:$HOME/.hsthrift/bin
+```
+
+```
+make all
 ```
 
 and test the installation with:
 ```
-make test BUILD_DEPS=1
+make test
 ```

--- a/README.md
+++ b/README.md
@@ -183,18 +183,23 @@ tag. They are all tagged regularly with tags like
 `v2021.01.11.00`. The `install_deps.sh` script will find the most
 recent tag and update all the repos to the same tag.
 
-# Building with fbcode\_builder/getdeps.py
+# Building with getdeps.py
 
-Experimental support for building hsthrift with the official Meta getdeps.py way is available.
-This is significantly smarter than the above method, but may build newer versions of some dependencies.
-For frequent development it will be faster, as it takes care of incremental builds better.
+Support for building hsthrift with the Meta getdeps.py tool is available. This
+avoids the need for sudo access to install folly and other dependencies.
 
-To install and build all dependencies (e.g. folly, fizz, fbthrift)
+To build and install the hsthrift dependencies:
 ```
-./build.sh build --allow-system-packages fbthrift
+./build.sh build --allow-system-packages --only-deps hsthrift
 ```
 
-You can then build hsthrift with `make` as above, or use getdeps.py again:
+You can then build hsthrift with `make` as follows:
+
 ```
-./build.sh build --allow-system-packages hsthrift
+make all BUILD_DEPS=1
+```
+
+and test the installation with:
+```
+make getdeps-test BUILD_DEPS=1
 ```

--- a/README.md
+++ b/README.md
@@ -201,5 +201,5 @@ make all BUILD_DEPS=1
 
 and test the installation with:
 ```
-make getdeps-test BUILD_DEPS=1
+make test BUILD_DEPS=1
 ```

--- a/build/fbcode_builder/manifests/hsthrift
+++ b/build/fbcode_builder/manifests/hsthrift
@@ -26,4 +26,5 @@ builder = nop
 builder = make
 
 [make.build_args]
-BUILD_DEPS=1 all
+BUILD_DEPS=1
+all

--- a/build/fbcode_builder/manifests/hsthrift
+++ b/build/fbcode_builder/manifests/hsthrift
@@ -26,5 +26,4 @@ builder = nop
 builder = make
 
 [make.build_args]
-BUILD_DEPS=1
 all

--- a/new_install_deps.sh
+++ b/new_install_deps.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+#
+# These are source deps not satisifiable with common package systems
+# in topological order
+#
+DEPS="fizz folly wangle fbthrift"
+
+set -e
+
+BUILDER=./build.sh
+
+build() {
+    ${BUILDER} build --no-deps --install-dir="$INSTALL_PREFIX" "$1"
+}
+
+# build in order
+for dep in $DEPS; do
+    build $dep
+done

--- a/new_install_deps.sh
+++ b/new_install_deps.sh
@@ -6,11 +6,16 @@
 # These are source deps not satisifiable with common package systems
 # in topological order
 #
-DEPS="fizz folly wangle fbthrift"
+DEPS="folly fizz wangle fbthrift"
 
 set -e
 
 BUILDER=./build.sh
+
+# default library and bin install path
+if [ -z "${INSTALL_PREFIX}" ]; then
+    INSTALL_PREFIX="${HOME}/.hsthrift"
+fi
 
 build() {
     ${BUILDER} build --no-deps --install-dir="$INSTALL_PREFIX" "$1"
@@ -20,3 +25,6 @@ build() {
 for dep in $DEPS; do
     build $dep
 done
+
+# add these to your environment
+echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:+:${INSTALL_PREFIX}/lib"

--- a/new_install_deps.sh
+++ b/new_install_deps.sh
@@ -27,4 +27,6 @@ for dep in $DEPS; do
 done
 
 # add these to your environment
-echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:+:${INSTALL_PREFIX}/lib"
+echo "export LD_LIBRARY_PATH=${INSTALL_PREFIX}/lib"
+echo "export PKG_CONFIG_PATH=${INSTALL_PREFIX}/lib/pkgconfig"
+echo "export PATH="'$PATH'":${INSTALL_PREFIX}/bin"

--- a/new_install_deps.sh
+++ b/new_install_deps.sh
@@ -23,10 +23,10 @@ build() {
 
 # build in order
 for dep in $DEPS; do
-    build $dep
+    build "$dep"
 done
 
 # add these to your environment
 echo "export LD_LIBRARY_PATH=${INSTALL_PREFIX}/lib"
 echo "export PKG_CONFIG_PATH=${INSTALL_PREFIX}/lib/pkgconfig"
-echo "export PATH="'$PATH'":${INSTALL_PREFIX}/bin"
+echo "export PATH=\$PATH:${INSTALL_PREFIX}/bin"


### PR DESCRIPTION
This adds a few tweaks and fixes to allow hsthrift to build using only getdeps.py-built dependencies, removing the need for sudo or global package paths or LD_* settings.

The new style removes the need for hsthrift/install)_deps.sh (--sudo --nuke) etc. Instead

$ ./build.sh build --only-deps --allow-system-packages hsthrift

then build against those user-space libs

$ make all BUILD_DEPS=1

We need quite a few env vars set up as half a dozen libraries are installed in the getdeps registry, instead of /usr/local.

We continue to support the (legacy?) build style for now, and its the default in the ci.yml

Once this has landed there is a small update to Glean/ to use this build style