### PR TITLE
Better support for building hsthrift deps with getdeps.py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,55 @@ jobs:
       - name: Run testsuites
         run: cabal test mangle fb-util thrift-compiler thrift-lib thrift-cpp-channel thrift-server thrift-tests --keep-going
         working-directory: ./_sdists
+
+  # check we can build the nosudo way. Deps in $HOME/.hsthrift
+  # note the tedious path setting here. We should set these in the image itself
+  ci-nosudo:
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: [8.10.7]
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/facebookincubator/hsthrift/ci-base:ghcup
+      options: --cpus 2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install ninja
+        run: apt install ninja-build
+      - name: Install folly, fizz, wangle, fbthrift
+        run: ./new_install_deps.sh
+      - name: Add fbthrift/thrift1 to PATH
+        run: echo "$HOME/.hsthrift/bin" >> $GITHUB_PATH
+      - name: Install ${{ matrix.ghc }}
+        run: ghcup install ghc ${{ matrix.ghc }} --set
+      - name: Install cabal-install-3.6
+        run: ghcup install cabal -u https://downloads.haskell.org/~cabal/cabal-install-3.6.0.0/cabal-install-3.6.0.0-x86_64-linux.tar.xz 3.6.0.0 --set
+      - name: Add GHC and cabal to PATH
+        run: echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
+      - name: Populate hackage index
+        run: cabal update
+      - name: Generate C++ code from thrift files
+        run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" make thrift-cpp
+      - name: Build everything up to thrift-compiler
+        run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" cabal build --project-file=ci.cabal.project exe:thrift-compiler
+      - name: Generate Haskell code from thrift files
+        run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" make thrift-hs
+      - name: Generate source distributions for all packages
+        run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" cabal sdist --project-file=ci.cabal.project all
+      - name: Unpack source distributions in new directory
+        run: |
+          mkdir _sdists
+          cd _sdists
+          for f in $(ls ../dist-newstyle/sdist/*.tar.gz); do
+            tar xzf $f;
+          done
+          cp ../ci-sdist.cabal.project cabal.project
+          cd ..
+      - name: Build all packages
+        run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" cabal build all
+        working-directory: ./_sdists
+      - name: Run testsuites
+        run: env LD_LIBRARY_PATH="$HOME/.hsthrift/lib" PKG_CONFIG_PATH="$HOME/.hsthrift/lib/pkgconfig" cabal test mangle fb-util thrift-compiler thrift-lib thrift-cpp-channel thrift-server thrift-tests --keep-going
+        working-directory: ./_sdists

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,11 @@
 # These are a few rules to help build the open-source hsthrift. This
 # file will hopefully go away in due course.
+#
 
-ifeq ($(BUILD_DEPS),1)
-	empty :=
-	space := $(empty) $(empty)
-	BUILDER := ./build.sh
+CABAL_BIN := cabal
 
-	DEPS := $(shell $(BUILDER) show-inst-dir hsthrift --recursive)
-	LIBDIRS := $(patsubst %,--extra-lib-dirs=%/lib,$(DEPS))
-	INCLUDEDIRS := $(patsubst %,--extra-include-dirs=%/include,$(DEPS))
-	PKG_CONFIG_PATH := $(subst $(space),:,$(shell find $(DEPS) -name pkgconfig -type d))
-	LD_LIBRARY_PATH := $(subst $(space),:,$(patsubst %,%/lib,$(DEPS)))
-
-	THRIFT1 := $(patsubst %,%/bin/thrift1,$(shell $(BUILDER) show-inst-dir fbthrift))
-
-	CABAL=env PKG_CONFIG_PATH="$(PKG_CONFIG_PATH)" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" cabal $(LIBDIRS) $(INCLUDEDIRS)
-else
-	THRIFT1 := thrift1
-	CABAL := cabal
-endif
+THRIFT1 := thrift1
+CABAL := $(CABAL_BIN)
 
 all:: compiler thrift-hs thrift-cpp server
 

--- a/README.md
+++ b/README.md
@@ -183,18 +183,36 @@ tag. They are all tagged regularly with tags like
 `v2021.01.11.00`. The `install_deps.sh` script will find the most
 recent tag and update all the repos to the same tag.
 
-# Building with fbcode\_builder/getdeps.py
+# Building with getdeps.py
 
-Experimental support for building hsthrift with the official Meta getdeps.py way is available.
-This is significantly smarter than the above method, but may build newer versions of some dependencies.
-For frequent development it will be faster, as it takes care of incremental builds better.
+Support for building hsthrift with the Meta getdeps.py tool is available. This
+avoids the need for sudo access to install folly and other dependencies.
 
-To install and build all dependencies (e.g. folly, fizz, fbthrift)
+You should have installed the libraries mentioned above, as well as:
 ```
-./build.sh build --allow-system-packages fbthrift
+apt install  \
+    ninja-build \
+    cmake
 ```
 
-You can then build hsthrift with `make` as above, or use getdeps.py again:
+Now build and install the hsthrift source dependencies:
 ```
-./build.sh build --allow-system-packages hsthrift
+./new_install_deps.sh
+
+```
+
+Set your env variables to pick up the new libraries and binaries:
+```
+export LD_LIBRARY_PATH=$HOME/.hsthrift/lib:
+export PKG_CONFIG_PATH=$HOME/.hsthrift/lib/pkgconfig
+export PATH=$PATH:$HOME/.hsthrift/bin
+```
+
+```
+make all
+```
+
+and test the installation with:
+```
+cabal test all
 ```

--- a/build/fbcode_builder/manifests/hsthrift
+++ b/build/fbcode_builder/manifests/hsthrift
@@ -26,4 +26,4 @@ builder = nop
 builder = make
 
 [make.build_args]
-BUILD_DEPS=1 all
+all

--- a/new_install_deps.sh
+++ b/new_install_deps.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+#
+# These are source deps not satisifiable with common package systems
+# in topological order
+#
+DEPS="folly fizz wangle fbthrift"
+
+set -e
+
+BUILDER=./build.sh
+THREADS=2
+
+# default library and bin install path
+if [ -z "${INSTALL_PREFIX}" ]; then
+    INSTALL_PREFIX="${HOME}/.hsthrift"
+fi
+
+build() {
+    ${BUILDER} build --no-deps --install-dir="${INSTALL_PREFIX}" \
+        --num-jobs="${THREADS}" "$1"
+}
+
+# build in order
+for dep in $DEPS; do
+    build "$dep"
+done
+
+# add these to your environment
+echo "export LD_LIBRARY_PATH=${INSTALL_PREFIX}/lib"
+echo "export PKG_CONFIG_PATH=${INSTALL_PREFIX}/lib/pkgconfig"
+echo "export PATH=\$PATH:${INSTALL_PREFIX}/bin"


### PR DESCRIPTION
getdeps tends to over-build dependencies for hsthrift, not realizing they are resolved by system packages. This leads to longer build times and a more complicated linker environment.

In projects like folly, this is solved by deleting e.g. openssl from the manifest, to make it an implicit system dep. We can't do that, but we can just use --no-deps pointwise build of the dependencies.

Benefits:
- we get to use getdeps.py, which simplifies how to build
- and doesn't need sudo

We still have to teach cabal about LD_LIBRARY_PATHS and PKG_CONFIG_PATH as in the old style, but we avoid requiring root privs to install now.

To use:
./new_install_deps.sh 
make as before

This PR updates the ci.yml to be green, and uses -j2 to build folly , bringing build times back in line with old ./install_deps.sh