### PR TITLE
Add support for installing additional packages from cmd line args

### DIFF
--- a/build/fbcode_builder/manifests/rocksdb
+++ b/build/fbcode_builder/manifests/rocksdb
@@ -1,9 +1,8 @@
 [manifest]
 name = rocksdb
 
-[download]
-url = https://github.com/facebook/rocksdb/archive/v6.8.1.tar.gz
-sha256 = ca192a06ed3bcb9f09060add7e9d0daee1ae7a8705a3d5ecbe41867c5e2796a2
+[git]
+repo_url = https://github.com/facebook/rocksdb.git
 
 [dependencies]
 lz4
@@ -11,7 +10,6 @@ snappy
 
 [build]
 builder = cmake
-subdir = rocksdb-6.8.1
 
 [cmake.defines]
 WITH_SNAPPY=ON

--- a/new_install_deps.sh
+++ b/new_install_deps.sh
@@ -2,30 +2,33 @@
 
 # Copyright (c) Facebook, Inc. and its affiliates.
 
-#
-# These are source deps not satisifiable with common package systems
-# in topological order
-#
-DEPS="folly fizz wangle fbthrift"
-
 set -e
 
 BUILDER=./build.sh
-THREADS=2
+THREADS=4
+
+#
+# These are required source deps not satisifiable with common package systems
+# in topological order. You can pass additional deps on the command line.
+#
+DEPS="folly fizz wangle fbthrift"
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --threads) THREADS="$2"; shift; shift;;
+        *) DEPS+=" $1"; shift;;
+    esac
+done
 
 # default library and bin install path
 if [ -z "${INSTALL_PREFIX}" ]; then
     INSTALL_PREFIX="${HOME}/.hsthrift"
 fi
 
-build() {
-    ${BUILDER} build --no-deps --install-dir="${INSTALL_PREFIX}" \
-        --num-jobs="${THREADS}" "$1"
-}
-
 # build in order
 for dep in $DEPS; do
-    build "$dep"
+    ${BUILDER} build --no-deps --install-dir "${INSTALL_PREFIX}" \
+        --num-jobs "${THREADS}" "$dep"
 done
 
 # add these to your environment


### PR DESCRIPTION
This extends the deps installer with enough smarts to install additional packages on the command line.
We do this so that Glean can ask the hsthrift build_deps.py to also solve the rocksdb source dependency, which is now required.

No changes to hsthrift itself, but this will unblock glean. Updates the rocksdb manifest we use to point at git.