### PR TITLE
Migrate from googletest 1.8 to googletest 1.10

### DIFF
--- a/build/fbcode_builder/manifests/mvfst
+++ b/build/fbcode_builder/manifests/mvfst
@@ -25,7 +25,7 @@ folly
 fizz
 
 [dependencies.all(test=on, not(os=windows))]
-googletest_1_8
+googletest
 
 [shipit.pathmap]
 fbcode/quic/public_root = .

--- a/build/fbcode_builder/manifests/proxygen
+++ b/build/fbcode_builder/manifests/proxygen
@@ -32,7 +32,7 @@ wangle
 mvfst
 
 [dependencies.test=on]
-googletest_1_8
+googletest
 
 [shipit.pathmap]
 fbcode/proxygen/public_tld = .

--- a/server/test/HaskellProcessorTest.cpp
+++ b/server/test/HaskellProcessorTest.cpp
@@ -31,18 +31,19 @@ struct MockResponseChannelRequest : public ResponseChannelRequest {
     return true;
   }
 
-  MOCK_METHOD3(
+  MOCK_METHOD(
+      void,
       sendReply,
-      void(
-          ResponsePayload&&,
-          MessageChannel::SendCallback*,
-          folly::Optional<uint32_t>));
+      (ResponsePayload&&,
+       MessageChannel::SendCallback*,
+       folly::Optional<uint32_t>));
 
-  MOCK_METHOD2(
+  MOCK_METHOD(
+      void,
       sendException,
-      void(ResponsePayload&&, MessageChannel::SendCallback*));
+      (ResponsePayload&&, MessageChannel::SendCallback*));
 
-  MOCK_METHOD2(sendErrorWrapped, void(folly::exception_wrapper, std::string));
+  MOCK_METHOD(void, sendErrorWrapped, (folly::exception_wrapper, std::string));
 
   bool active;
   size_t& destroyed;


### PR DESCRIPTION
Summary: Updating `googletest` from `1.8.0` to `1.10.0`

Reviewed By: mzlee, igorsugak, luciang, meyering, r-barnes

Differential Revision: D34351084

