### PR TITLE
Necessary bits to build hsthrift with clang

### DIFF
--- a/.github/workflows/Dockerfile.clang
+++ b/.github/workflows/Dockerfile.clang
@@ -1,0 +1,59 @@
+#
+# This produces the image that is used for running the github actions
+# CI jobs.
+#
+FROM ubuntu:22.04
+ENV TZ=Europe/London
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+RUN apt-get update
+RUN apt-get install -y \
+    clang-11 llvm \
+    cmake \
+    ninja-build \
+    bison flex \
+    git \
+    libzstd-dev \
+    libboost-all-dev \
+    libevent-dev \
+    libdouble-conversion-dev \
+    libgoogle-glog-dev \
+    libgflags-dev \
+    libiberty-dev \
+    liblz4-dev \
+    liblzma-dev \
+    libsnappy-dev \
+    make \
+    zlib1g-dev \
+    binutils-dev \
+    libjemalloc-dev \
+    libssl-dev \
+    pkg-config \
+    libunwind-dev \
+    libsodium-dev \
+    curl \
+    libpcre3-dev \
+    libmysqlclient-dev \
+    libfftw3-dev \
+    libgmp-dev \
+    libtinfo-dev
+
+# set default C compiler
+RUN apt-get remove -y gcc-11
+RUN update-alternatives --install /usr/bin/cc cc /usr/bin/clang-11 10
+RUN update-alternatives --set cc /usr/bin/clang-11
+RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-11 10
+RUN update-alternatives --set c++ /usr/bin/clang++-11
+# needed for hsc2hs
+RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/clang++-11 10
+# needed for ghc
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/clang-11 10
+
+# install ghcup
+ARG GHCUP_VERSION=0.1.17.4
+RUN curl --proto '=https' --tlsv1.2 -sSf https://downloads.haskell.org/~ghcup/$GHCUP_VERSION/x86_64-linux-ghcup-$GHCUP_VERSION > /usr/bin/ghcup && \
+    chmod +x /usr/bin/ghcup
+
+ARG GITHUB_HOME=/github/home
+ENV PATH=$GITHUB_HOME/.ghcup/bin:$GITHUB_HOME/.hsthrift/bin:$PATH
+ENV LD_LIBRARY_PATH=$GITHUB_HOME/.hsthrift/lib:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
+ENV PKG_CONFIG_PATH=$GITHUB_HOME/.hsthrift/lib/pkgconfig:$PKG_CONFIG_PATH

--- a/build.sh
+++ b/build.sh
@@ -17,6 +17,13 @@ if [ "$arch" == x86_64 ] ; then
     export CXXFLAGS=-march=corei7
 fi
 
+# if the C++ compiler is clang, we need fbthrift to build with -fsized-deallocation
+# this is a janky way to make that happen until we work out how to patch fbthrift
+clang=$(cc --version | sed -n 's/^.*\(clang\).*$/\1/p')
+if [ -n "$clang" ] ; then
+    export CXXFLAGS="$CXXFLAGS -fsized-deallocation"
+fi
+
 # N.B. we always need shared libs, but this only checks build is the first arg
 if [ "$1" = "build" ]; then
     set -- "$@" --extra-cmake-defines='{"BUILD_SHARED_LIBS": "ON", "BUILD_EXAMPLES": "off", "BUILD_TESTS": "off", "CMAKE_INSTALL_RPATH_USE_LINK_PATH": "TRUE", "EVENT__BUILD_SHARED_LIBRARIES": "ON"}'

--- a/cpp-channel/thrift-cpp-channel.cabal
+++ b/cpp-channel/thrift-cpp-channel.cabal
@@ -91,7 +91,7 @@ library
 
     hs-source-dirs: .
     build-tool-depends: hsc2hs:hsc2hs
-    hsc2hs-options: --cc=g++ --lflag=-lstdc++ --cflag=-D__HSC2HS__=1 --lflag=-lboost_context --cflag=-std=c++17
+    hsc2hs-options: --cc=g++ --lflag=-lstdc++ --cflag=-D__HSC2HS__=1 --lflag=-lboost_context --lflag=-latomic --cflag=-std=c++17
     include-dirs: .
 
     pkgconfig-depends: libfolly, fmt, openssl, libsodium
@@ -111,6 +111,8 @@ library
         -- TODO: I needed this to satisfy an undefined reference to
         -- jump_fcontext when running hsc2hs
         boost_context
+        -- __atomic_is_lock_free (-latomic) missing with clang
+        atomic
 
     build-depends:
         base >=4.11.1 && <4.15,


### PR DESCRIPTION
- dockerfile based on base-ci, but upgrade to ubuntu 22, remove gcc and install clang only.
- clang needs to know where libatomic is when we do hsc2hs stuff
- one extra clang flag to compile fbthrift, fsized-deallocation