### PR TITLE
Cache location of thrift-compiler binary between thrift generation steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ util::
 
 thrift:: thrift-cpp thrift-hs
 
-THRIFT_COMPILE = $(CABAL) run exe:thrift-compiler --
+THRIFT_COMPILE := $(shell $(CABAL) list-bin exe:thrift-compiler)
 
 thrift-hs::
 	(cd lib && $(THRIFT_COMPILE) --hs \


### PR DESCRIPTION
The thrift-hs target was re-analyzing the cabal package for
thrift-compiler on every invocation. This takes about 1.1s per
invocation. Instead, cache it and reuse the result.

Before:
> time make thrift-hs
> real	0m35.026s

After:
> time make thrift-hs
> real	0m1.857s

17x speedup for this target.