### PR TITLE
Update libfmt to 8.1.1

### DIFF
--- a/build/fbcode_builder/manifests/fmt
+++ b/build/fbcode_builder/manifests/fmt
@@ -2,12 +2,12 @@
 name = fmt
 
 [download]
-url = https://github.com/fmtlib/fmt/archive/refs/tags/8.0.1.tar.gz
-sha256 = b06ca3130158c625848f3fb7418f235155a4d389b2abc3a6245fb01cb0eb1e01
+url = https://github.com/fmtlib/fmt/archive/refs/tags/8.1.1.tar.gz
+sha256 = 3d794d3cf67633b34b2771eb9f073bde87e846e0d395d254df7b211ef1ec7346
 
 [build]
 builder = cmake
-subdir = fmt-8.0.1
+subdir = fmt-8.1.1
 
 [cmake.defines]
 FMT_TEST = OFF


### PR DESCRIPTION
Various fixes on the 8.x series. https://github.com/fmtlib/fmt/releases