### PR TITLE
Make thrift-cache rule more robust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ util::
 
 thrift:: thrift-cpp thrift-hs
 
-THRIFT_COMPILE := $(shell $(CABAL) list-bin exe:thrift-compiler)
+THRIFT_COMPILE := $(shell $(CABAL) -v0 list-bin exe:thrift-compiler)
 
 thrift-hs::
 	(cd lib && $(THRIFT_COMPILE) --hs \


### PR DESCRIPTION
The output of list-bin is sensitive to -v flags. If we use -vnormal or
above we might get spurious "Up to date" output on the cached key, which breaks the build.
Use -v0 on the cache rule to force cabal to just give us the path. This should be more resiliant if users set other flags.