### PR TITLE
Fix a couple of cabal warnings that have been around forever

### DIFF
--- a/common/mangle/mangle.cabal
+++ b/common/mangle/mangle.cabal
@@ -43,7 +43,7 @@ executable mangle
 
 test-suite mangle-test
   type: exitcode-stdio-1.0
-  hs-source-dirs: tests, tests/github
+  hs-source-dirs: tests
   default-language: Haskell2010
   default-extensions: LambdaCase
   main-is: Test.hs

--- a/lib/thrift-lib.cabal
+++ b/lib/thrift-lib.cabal
@@ -171,7 +171,6 @@ common test-deps
                  QuickCheck,
                  STMonadTrans,
                  thrift-lib:test-helpers,
-  ghc-options: -threaded
 
 -- This is used by local tests only
 library test-lib


### PR DESCRIPTION
- -threaded on a lib
- a tests dir that dosen't exist

hsthrift builds appear to be warning-free now