### PR TITLE
Make thrift-hs explicitly depend on the thrift-compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ thrift:: thrift-cpp thrift-hs
 
 THRIFT_COMPILE := $(shell $(CABAL) -v0 list-bin exe:thrift-compiler)
 
-thrift-hs::
+thrift-hs:: compiler
 	(cd lib && $(THRIFT_COMPILE) --hs \
 		if/RpcOptions.thrift)
 	(cd lib && $(THRIFT_COMPILE) --hs \


### PR DESCRIPTION
This ensures it is built before we try to generate .hs , as thus the
cache will work.

$ make -j4 

almost works now (!)