### PR TITLE
Suppress -Wterminate for createDynamic is marked noexcept but throws …

### DIFF
--- a/common/util/cpp/cdynamic.cpp
+++ b/common/util/cpp/cdynamic.cpp
@@ -113,8 +113,10 @@ void createDynamic(dynamic* ret, DType ty, DValue* val) noexcept {
       new (ret) dynamic(val->string);
       break;
     case dynamic::ARRAY:
+      #pragma GCC diagnostic ignored "-Wterminate"
       throw std::invalid_argument("call writeDynamicArray for dynamic::ARRAY");
     case dynamic::OBJECT:
+      #pragma GCC diagnostic ignored "-Wterminate"
       throw std::invalid_argument(
           "call writeDynamicObject for dynamic::OBJECT");
     default:


### PR DESCRIPTION
…(intentionally)

This is a slightly worrying looking warning, but we are intentionally
throwing (and std:terminating) in this noexecpt method. So mark it with
the pragma and make the warning go away

Without this you get a warning along the lines of "this will always
terminate and throws!" -- which we know.