### PR TITLE
rocksdb 7 is released, so switch to the released version

### DIFF
--- a/build/fbcode_builder/manifests/rocksdb
+++ b/build/fbcode_builder/manifests/rocksdb
@@ -1,8 +1,9 @@
 [manifest]
 name = rocksdb
 
-[git]
-repo_url = https://github.com/facebook/rocksdb.git
+[download]
+url = https://github.com/facebook/rocksdb/archive/refs/tags/v7.0.1.tar.gz
+sha256 = f1547be4dd76ca30d74e8d1377b893d36ecb7b526ffd835638ad34feb79be174
 
 [dependencies]
 lz4
@@ -10,6 +11,7 @@ snappy
 
 [build]
 builder = cmake
+subdir = rocksdb-7.0.1
 
 [cmake.defines]
 WITH_SNAPPY=ON


### PR DESCRIPTION
v7.* series should be api compatible with Glean