### PR TITLE
Update clang docker image with pre-built rocksdb step

### DIFF
--- a/.github/workflows/Dockerfile.clang
+++ b/.github/workflows/Dockerfile.clang
@@ -48,6 +48,9 @@ RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/clang++-11 10
 # needed for ghc
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/clang-11 10
 
+# clean up
+RUN apt-get -y autoremove
+
 # install ghcup
 ARG GHCUP_VERSION=0.1.17.4
 RUN curl --proto '=https' --tlsv1.2 -sSf https://downloads.haskell.org/~ghcup/$GHCUP_VERSION/x86_64-linux-ghcup-$GHCUP_VERSION > /usr/bin/ghcup && \
@@ -57,3 +60,9 @@ ARG GITHUB_HOME=/github/home
 ENV PATH=$GITHUB_HOME/.ghcup/bin:$GITHUB_HOME/.hsthrift/bin:$PATH
 ENV LD_LIBRARY_PATH=$GITHUB_HOME/.hsthrift/lib:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
 ENV PKG_CONFIG_PATH=$GITHUB_HOME/.hsthrift/lib/pkgconfig:$PKG_CONFIG_PATH
+
+# build rocksdb 7 from source and install
+# we use the hsthrift build manifest for consistency
+RUN git clone https://github.com/facebookincubator/hsthrift
+RUN cd hsthrift && ./build.sh build --no-deps --install-dir /usr/ --num-jobs 8 rocksdb
+RUN rm -rf /tmp/fbcode_builder_getdeps-ZhsthriftZbuildZfbcode_builder-root/ && rm -rf /hsthrift/


### PR DESCRIPTION
(i.e. get faster signal on the CI because we have fixed rocksdb to 7.0.1)

Example here: https://github.com/users/donsbot/packages/container/hsthrift%2Fci-base/16728028?tag=clang11rocksdb

Example Glean build against this image, ~1h30m instead of >2h

https://github.com/donsbot/Glean/actions/runs/1978473391
