### PR TITLE
Bump rocksdb stable to 7.0.2 (bug fix release)

### DIFF
--- a/build/fbcode_builder/manifests/rocksdb
+++ b/build/fbcode_builder/manifests/rocksdb
@@ -2,8 +2,8 @@
 name = rocksdb
 
 [download]
-url = https://github.com/facebook/rocksdb/archive/refs/tags/v7.0.1.tar.gz
-sha256 = f1547be4dd76ca30d74e8d1377b893d36ecb7b526ffd835638ad34feb79be174
+url = https://github.com/facebook/rocksdb/archive/refs/tags/v7.0.2.tar.gz
+sha256 = d808c87074aef7a4ea8e329b1b3de718a95cf2895dbe606036d75e66af10d05a
 
 [dependencies]
 lz4
@@ -11,7 +11,7 @@ snappy
 
 [build]
 builder = cmake
-subdir = rocksdb-7.0.1
+subdir = rocksdb-7.0.2
 
 [cmake.defines]
 WITH_SNAPPY=ON


### PR DESCRIPTION
https://github.com/facebook/rocksdb/releases/tag/v7.0.2 

Test plan:
 - build glean using hsthrift from donsbot/hsthrift -b dons-rocksdb, confirm build works
Once sync'd rebuild docker image.

```
Assessing rocksdb...
Download https://github.com/facebook/rocksdb/archive/refs/tags/v7.0.2.tar.gz -> /tmp/fbcode_builder_getdeps-ZhomeZdonsZGleanZhsthriftZbuildZfbcode_builder/downloads/rocksdb-v7.0.2.tar.gz ...
 downloading 9502720 of (Unknown)  [Complete in 1.659260 seconds]
Extract /tmp/fbcode_builder_getdeps-ZhomeZdonsZGleanZhsthriftZbuildZfbcode_builder/downloads/rocksdb-v7.0.2.tar.gz -> /tmp/fbcode_builder_getdeps-ZhomeZdonsZGleanZhsthriftZbuildZfbcode_builder/extracted/rocksdb-v7.0.2.tar.gz
Building rocksdb...

```