### PR TITLE
Downgrade clang container to ubuntu 20 (focal) to match hhvm binaries

### DIFF
--- a/.github/workflows/Dockerfile.clang
+++ b/.github/workflows/Dockerfile.clang
@@ -2,7 +2,7 @@
 # This produces the image that is used for running the github actions
 # CI jobs.
 #
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 ENV TZ=Europe/London
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN apt-get update
@@ -38,7 +38,7 @@ RUN apt-get install -y \
     libtinfo-dev
 
 # set default C compiler
-RUN apt-get remove -y gcc-11
+RUN apt-get remove -y gcc
 RUN update-alternatives --install /usr/bin/cc cc /usr/bin/clang-11 10
 RUN update-alternatives --set cc /usr/bin/clang-11
 RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-11 10
@@ -52,7 +52,7 @@ RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/clang-11 10
 RUN apt-get -y autoremove
 
 # install ghcup
-ARG GHCUP_VERSION=0.1.17.4
+ARG GHCUP_VERSION=0.1.17.5
 RUN curl --proto '=https' --tlsv1.2 -sSf https://downloads.haskell.org/~ghcup/$GHCUP_VERSION/x86_64-linux-ghcup-$GHCUP_VERSION > /usr/bin/ghcup && \
     chmod +x /usr/bin/ghcup
 


### PR DESCRIPTION
There's no packages for some jammy/hhvm dependencies yet, so we can downgrade.