### PR TITLE
Drop dependency on mysql in the OSS build

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ not have IPv6 configured.
 sudo apt install \
     libgoogle-glog-dev \
     libgflags-dev \
-    libmysqlclient-dev \
     bison \
     flex \
     ninja-build \
@@ -149,8 +148,7 @@ sudo yum install \
      pcre-devel \
      ncurses-devel \
      fmt-devel \
-     gmp-devel \
-     community-mysql-devel
+     gmp-devel
 ```
 
 Also you may need:

--- a/common/util/Util/TimeSec.hs
+++ b/common/util/Util/TimeSec.hs
@@ -1,5 +1,6 @@
 -- Copyright (c) Facebook, Inc. and its affiliates.
 
+{-# LANGUAGE CPP #-}
 module Util.TimeSec
   ( Time(..)
   , TimeSpan(..)
@@ -18,7 +19,9 @@ module Util.TimeSec
   , PPTimeSpanGranularity(..)
   ) where
 
+#ifdef FACEBOOK
 import Database.MySQL.Simple.Param
+#endif
 import Data.Aeson
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -39,8 +42,10 @@ newtype Time = Time { timeInSeconds :: Int }
 instance NFData   Time
 instance Hashable Time
 
+#ifdef FACEBOOK
 instance Param Time where
   render = render . timeInSeconds
+#endif
 
 -- | 'TimeSpan' means a time difference, duration in seconds,
 -- as opposed to 'Time', which is a specific point in time

--- a/common/util/fb-util.cabal
+++ b/common/util/fb-util.cabal
@@ -191,7 +191,6 @@ library
         aeson-pretty,
         either,
         QuickCheck,
-        mysql-simple,
         scientific,
         haskell-src-exts,
         stm,


### PR DESCRIPTION
This dep only exists for an instance of MySQL.Param, which is used no where in the OSS code.
Drop the dep entirely.

There's a separate fix to mysql-simple over on https://github.com/paul-rouse/mysql-simple/pull/56 , but we don't need to wait for it.