### PR TITLE
fb-util: Include alignedAlloc in compilation

### DIFF
--- a/common/util/fb-util.cabal
+++ b/common/util/fb-util.cabal
@@ -157,6 +157,7 @@ library
         cpp/HsStruct.cpp
         cpp/IOBuf.cpp
         cpp/EventBaseDataplane.cpp
+        Util/AsanAlloc.cpp
         -- Util/GFlags.cpp
 
     install-includes:
@@ -167,6 +168,8 @@ library
         cpp/ffi.h
         cpp/memory.h
         cpp/wrap.h
+        Util/AsanAlloc.h
+  
     include-dirs: .
     hs-source-dirs: .
 


### PR DESCRIPTION
AsanAlloc.cpp defines alignedAlloc which in return is exported as an FFI in ASan.hs cAlignedAlloc. If we don't include AsanAlloc.cpp in cxx-sources, it will be missing from compilation. In most instances this can be okay, as lazy loading usually prevents an error from appearing. However in instances where a linker requires it to be there, it will fail, such as on compiling hsthrift + glean on NixOS, leading to the linker aborting due to missing symbol asanAlloc. The right thing here is to make sure all functions we export in the FFI are available.

One open question here for peopl with deeper understanding of cabal+cxx compilation, is to include the header file in install-includes or not. For now i did not as it was not required to make the compilation succeed.