### PR TITLE
add `HsSet` to cabal

### DIFF
--- a/common/util/fb-util.cabal
+++ b/common/util/fb-util.cabal
@@ -81,6 +81,7 @@ library
         Foreign.CPP.HsStruct
         Foreign.CPP.HsStruct.HsArray
         Foreign.CPP.HsStruct.HsOption
+        Foreign.CPP.HsStruct.HsSet
         Foreign.CPP.HsStruct.HsStdVariant
         Foreign.CPP.HsStruct.Types
         Foreign.CPP.HsStruct.Unsafe


### PR DESCRIPTION
Summary: Adds `HsSet` to cabal build

Differential Revision: D38879680

