### PR TITLE
Replace the dependency on dependent-sum with some.

### DIFF
--- a/lib/thrift-lib.cabal
+++ b/lib/thrift-lib.cabal
@@ -150,7 +150,7 @@ common test-deps
   build-depends: async ^>= 2.2,
                  base,
                  bytestring,
-                 dependent-sum,
+                 some,
                  fb-stubs,
                  fb-util,
                  filepath,


### PR DESCRIPTION
Summary: We don't actually use the modules in dependent-sum anymore since it was split up. We're only using the modules from the some package which is re-exported from dependent-sum

Reviewed By: helfper

Differential Revision: D40184427

