### PR TITLE
Add ghc-prim to build-depends for gen-hs2

### DIFF
--- a/cpp-channel/thrift-cpp-channel.cabal
+++ b/cpp-channel/thrift-cpp-channel.cabal
@@ -162,6 +162,7 @@ test-suite header-channel
   build-depends:
                   base,
                   bytestring,
+                  ghc-prim,
                   thrift-cpp-channel:thrift-cpp-channel,
                   fb-stubs,
                   thrift-lib:thrift-lib,

--- a/lib/thrift-lib.cabal
+++ b/lib/thrift-lib.cabal
@@ -91,6 +91,7 @@ library
     extra-libraries: stdc++
 
     build-depends:
+        ghc-prim,
         dependent-sum >= 0.6 && <= 0.6.2.0,
           -- TODO: Data.Some was split out into package some at 0.6.2.2,
           -- deprecated 'This' was removed.
@@ -149,6 +150,7 @@ common test-deps
     cxx-options: -DIPV4
   build-depends: async ^>= 2.2,
                  base,
+                 ghc-prim,
                  bytestring,
                  some,
                  fb-stubs,

--- a/server/thrift-server.cabal
+++ b/server/thrift-server.cabal
@@ -118,6 +118,7 @@ common test-deps
                  hashable,
                  hspec,
                  hspec-contrib,
+                 ghc-prim,
                  HUnit ^>= 1.6.1,
                  STMonadTrans,
                  text,

--- a/tests/thrift-tests.cabal
+++ b/tests/thrift-tests.cabal
@@ -74,6 +74,7 @@ common test-common
                  deepseq,
                  either,
                  fb-stubs,
+                 ghc-prim,
                  hashable,
                  hspec,
                  hspec-contrib,


### PR DESCRIPTION
Needed by recent changes to the Thrift compiler