### PR TITLE
Add HTTP transport

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,17 @@ thrift-hs:: compiler
 		test/if/math.thrift \
 		-o ../server/test)
 	(cd lib && $(THRIFT_COMPILE) --hs --use-int \
+		test/if/math.thrift \
+		-o ../http/test)
+	(cd lib && $(THRIFT_COMPILE) --hs --use-int \
 		test/if/echoer.thrift \
 		-o test)
 	(cd lib && $(THRIFT_COMPILE) --hs --use-int \
 		test/if/echoer.thrift \
 		-o ../server/test)
+	(cd lib && $(THRIFT_COMPILE) --hs --use-int \
+		test/if/echoer.thrift \
+		-o ../http/test)
 	(cd server && $(THRIFT_COMPILE) --hs \
 		test/if/hash_map.thrift \
 		-o test)

--- a/cabal.project
+++ b/cabal.project
@@ -10,5 +10,6 @@ packages:
     tests/thrift-tests.cabal
     haxl/thrift-haxl.cabal
     cpp-channel/thrift-cpp-channel.cabal
+    http/thrift-http.cabal
 
 tests: true

--- a/http/LICENSE
+++ b/http/LICENSE
@@ -1,0 +1,30 @@
+BSD License
+
+For hsthrift software
+
+Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name Facebook nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/http/Thrift/Channel/HTTP.hs
+++ b/http/Thrift/Channel/HTTP.hs
@@ -1,0 +1,96 @@
+module Thrift.Channel.HTTP (
+    HTTPConfig(..),
+    withHTTPChannel,
+    withHTTPChannelIO,
+  ) where
+
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Lazy as LBS
+import Data.Proxy
+import qualified Data.Text.Encoding as Text
+import Network.HTTP.Client hiding (Proxy)
+import Network.HTTP.Types.Status
+
+import Thrift.Channel
+import Thrift.Monad
+import Thrift.Protocol
+import Thrift.Protocol.Id
+
+data HTTPChannel s = HTTPChannel
+  { httpConfig :: HTTPConfig s
+  , httpManager :: Manager
+  }
+
+data HTTPConfig s = HTTPConfig
+  { httpHost :: ByteString
+  , httpPort :: Int
+  , httpProtocolId :: ProtocolId
+  , httpResponseTimeout :: Maybe Int -- ^ microseconds
+  }
+  deriving Show
+
+withHTTPChannel
+    :: HTTPConfig t
+    -> (forall p . Protocol p => ThriftM p HTTPChannel t a)
+    -> IO a
+withHTTPChannel config@HTTPConfig{..} action = do
+  manager <- newManager defaultManagerSettings {
+    managerResponseTimeout =
+      maybe responseTimeoutNone responseTimeoutMicro httpResponseTimeout }
+  withProxy httpProtocolId $ \proxy ->
+    runAction (HTTPChannel config manager) action proxy
+  where
+    runAction
+      :: Protocol p
+      => HTTPChannel t
+      -> ThriftM p HTTPChannel t a
+      -> Proxy p
+      -> IO a
+    runAction c a _ = runThrift a c
+
+withHTTPChannelIO
+    :: HTTPConfig t
+    -> (forall p . Protocol p => HTTPChannel t -> Proxy p -> IO a)
+    -> IO a
+withHTTPChannelIO config@HTTPConfig{..} action = do
+  manager <- newManager defaultManagerSettings
+  withProxy httpProtocolId $ \proxy ->
+    action (HTTPChannel config manager) proxy
+
+instance ClientChannel HTTPChannel where
+  sendRequest = httpRequest
+  sendOnewayRequest chan req sendCb = httpRequest chan req sendCb (\_ -> return ())
+
+httpRequest
+  :: HTTPChannel t
+  -> Thrift.Channel.Request
+  -> SendCallback
+  -> RecvCallback
+  -> IO ()
+httpRequest HTTPChannel{..} Request{..} sendCb recvCb = do
+    let !prot = httpProtocolId httpConfig
+    let request = defaultRequest
+          { host = httpHost httpConfig
+          , port = httpPort httpConfig
+          , method = "POST"
+          , requestHeaders =
+              [ ("Content-Type", if
+                  | prot == binaryProtocolId ->
+                      "application/x-thrift-binary"
+                  | prot == compactProtocolId ->
+                      "application/x-thrift-compact"
+                  | otherwise -> -- later: JSON
+                      "application/x-thrift-binary") ]
+          , requestBody = RequestBodyBS reqMsg
+          }
+          -- TODO: rpcOpts
+    response <- httpLbs request httpManager
+    sendCb Nothing -- TODO?
+    let s = responseStatus response
+    if
+      | s == status200 ->
+        recvCb $ Right Response
+          { respMsg = LBS.toStrict (responseBody response)
+          , respHeader = [] }
+      | otherwise ->
+        recvCb (Left (ChannelException (Text.decodeUtf8 (statusMessage s))))

--- a/http/Thrift/Server/HTTP.hs
+++ b/http/Thrift/Server/HTTP.hs
@@ -1,0 +1,121 @@
+-- | Support for creating a Thrift-over-HTTP server
+
+{-# LANGUAGE TypeApplications #-}
+module Thrift.Server.HTTP (
+    ServerOptions(..),
+    Server(..),
+    defaultOptions,
+    withBackgroundServer,
+    thriftApplication,
+  ) where
+
+import Data.ByteString (ByteString)
+import Control.Concurrent
+import Control.Concurrent.Async
+import Control.Exception
+import qualified Data.ByteString.Lazy as LBS
+import Data.Proxy
+import Data.String
+import Data.Streaming.Network (bindPortTCP, bindRandomPortTCP)
+import Network.HTTP.Types
+import Network.Socket (close)
+import Network.Wai.Handler.Warp
+import Network.Wai
+
+import Thrift.Processor
+import Thrift.Protocol
+import Thrift.Protocol.Binary
+import Thrift.Protocol.Compact
+import Thrift.Protocol.JSON
+
+-- TODO:
+--  - one-way requests are currently treated as 2-way. Can we do any
+--    better?
+
+-- | Options for creating a Thrift-over-HTTP service.
+data ServerOptions = ServerOptions
+  { desiredPort :: Maybe Int
+     -- ^ If 'Nothing', creates the server on a random free port,
+     -- passing the actual port number as 'serverPort'.
+  , numWorkerThreads :: Maybe Int
+     -- ^ Currently ignored, provided for compatibility with CppServer
+  , warpSettings :: Settings
+  }
+
+-- | Default options for creating a Thrift-over-HTTP service.
+defaultOptions :: ServerOptions
+defaultOptions = ServerOptions
+  { desiredPort = Nothing
+  , numWorkerThreads = Nothing
+  , warpSettings = setHost (fromString "!6") defaultSettings
+      -- IPv6 only by default
+  }
+
+-- | A running HTTP server.
+data Server = Server
+  { serverPort :: Int
+      -- The actual port number, which might be useful if
+      -- 'desiredPort' was 'Nothing'.
+  , serverAsync :: Async ()
+      -- The 'Async' running the HTTP server
+  }
+
+-- | Create an HTTP server for a Thrift service from the given 'ServerOptions'.
+-- This is a simple wrapper around Warp's 'runSettings' that optionally creates
+-- the server on a random port, and also wait for the server to start before
+-- invoking the given action. Shuts down the server when the action returns.
+withBackgroundServer
+  :: forall s a . (Processor s)
+  => (forall r . s r -> IO r) -- ^ handler to use
+  -> ServerOptions
+  -> (Server -> IO a)  -- ^ action to run while the server is up
+  -> IO a
+withBackgroundServer handler ServerOptions{..} action = do
+  ready <- newEmptyMVar
+  let
+    host = getHost warpSettings
+    application = thriftApplication handler
+
+    settings =
+      maybe id setPort desiredPort $
+      setBeforeMainLoop (putMVar ready ()) $
+      warpSettings
+
+    go port sock =
+      withAsync (runSettingsSocket settings sock application) $ \a -> do
+        takeMVar ready
+        action (Server port a)
+
+  case desiredPort of
+    Nothing ->
+      bracket (bindRandomPortTCP host) (close . snd) $ \(port,sock) ->
+        go port sock
+    Just port ->
+      bracket (bindPortTCP port host) close (go port)
+
+-- | Make a WAI 'Application' for a Thrift service. Use this with a
+-- transport layer such as Warp to make a complete server, or call
+-- 'withBackgroundServer' to do it all.
+thriftApplication
+  :: forall s a . (Processor s)
+  => (forall r . s r -> IO r) -- ^ handler to use
+  -> Application
+thriftApplication handler req respond = do
+  body <- strictRequestBody req
+  withProto (requestHeaders req) $ \proto contentType -> do
+    (res, _maybeEx) <- process proto 0 handler (LBS.toStrict body)
+    respond $ responseLBS
+      status200
+      [(hContentType, contentType)]
+      (LBS.fromStrict res)
+  where
+  withProto
+   :: [Header]
+   -> (forall p . Protocol p => Proxy p -> ByteString -> IO b)
+   -> IO b
+  withProto hdrs f =
+    case [ t | (header,t) <- hdrs, header == hContentType ] of
+      (t@"application/x-thrift-binary") : _ -> f (Proxy @Binary) t
+      (t@"application/x-thrift-compact") : _ -> f (Proxy @Compact) t
+      (t@"application/x-thrift-json") : _ -> f (Proxy @JSON) t
+      _ -> f (Proxy @Binary) "application/x-thrift-binary"

--- a/http/Thrift/Server/Http.hs
+++ b/http/Thrift/Server/Http.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE TypeApplications #-}
+module Thrift.Server.HTTP (
+    ServerOptions(..),
+    Server(..),
+    defaultOptions,
+    withBackgroundServer,
+  ) where
+
+import Control.Concurrent.Async
+import qualified Data.ByteString.Lazy as LBS
+import Data.Proxy
+import Network.HTTP.Types
+import Network.Wai.Handler.Warp
+import Network.Wai.Handler.Warp.Internal
+import Network.Wai
+
+import Thrift.Processor
+import Thrift.Protocol.Binary
+
+-- TODO:
+--  - select protocol with header?
+--  - do we have to do something to select body encoding?
+--  - signal handling, background server?
+--  - exceptions? result status?
+
+data ServerOptions = ServerOptions
+  { desiredPort :: Maybe Int
+  , numWorkerThreads :: Maybe Int
+  }
+
+defaultOptions :: ServerOptions
+defaultOptions = ServerOptions
+  { desiredPort = Nothing
+  , numWorkerThreads = Nothing
+  }
+
+data Server = Server
+  { serverPort :: Int
+  , serverAsync :: Async ()
+  }
+
+withBackgroundServer
+  :: forall s a . (Processor s)
+  => (forall r . s r -> IO r) -- ^ handler to use
+  -> ServerOptions
+  -> (Server -> IO a)
+  -> IO a
+withBackgroundServer handler ServerOptions{..} action = do
+  withAsync (runSettings settings application) $ \a ->
+    action (Server (settingsPort settings) a)
+  where
+  settings = maybe id setPort desiredPort defaultSettings
+  application req respond = do
+    body <- strictRequestBody req
+    (res, _maybeEx) <- process (Proxy @Binary) 0 handler (LBS.toStrict body)
+    respond $ responseLBS
+      status200
+      [("Content-Type", "application/x-thrift-binary")]
+      (LBS.fromStrict res)

--- a/http/test/ServerTest.hs
+++ b/http/test/ServerTest.hs
@@ -1,0 +1,138 @@
+-- Copyright (c) Facebook, Inc. and its affiliates.
+
+module ServerTest (main) where
+
+import Control.Exception hiding (DivideByZero)
+import Control.Monad
+import Control.Monad.Trans.Class
+import Data.Either
+
+import Facebook.Init
+-- import Network (testServerHost)
+import Test.HUnit
+import TestRunner
+
+import Thrift.Api
+import Thrift.Monad
+import Thrift.Protocol.ApplicationException.Types
+import Thrift.Protocol.Id
+import Thrift.Channel.HTTP
+import Thrift.Server.HTTP
+
+import Math.Adder.Client
+import Math.Calculator.Client
+import Math.Types
+import Echoer.Echoer.Client
+import EchoHandler
+
+withTestServer :: ServerOptions -> (Int -> IO a) -> IO a
+withTestServer serverOptions action = do
+  st <- initEchoerState
+  withBackgroundServer (echoHandler st) serverOptions $
+    \Server{..} -> action serverPort
+
+mkHTTPConfig :: Int -> ProtocolId -> HTTPConfig t
+mkHTTPConfig port protId =
+  HTTPConfig
+    { httpHost = "localhost" --testServerHost
+    , httpPort = port
+    , httpProtocolId = protId
+    , httpResponseTimeout = Nothing
+    }
+
+mkServerTest
+  :: String
+  -> String
+  -> ProtocolId
+  -> Thrift Echoer ()
+  -> Test
+mkServerTest pname label protId action =
+  TestLabel (pname ++ " " ++ label) $ TestCase $
+    withTestServer defaultOptions $ \port -> do
+      let httpConf = mkHTTPConfig port protId
+      withHTTPChannel httpConf action
+
+-- Calculator function
+addTest :: String -> ProtocolId -> Test
+addTest pname protId = mkServerTest pname "add test" protId $ do
+  res <- add 5 2
+  lift $ assertEqual "5 + 2 = 7" 7 res
+
+-- Calculator function
+divideTest :: String -> ProtocolId -> Test
+divideTest pname protId = mkServerTest pname "divide test" protId $ do
+  res <- divide 9 3
+  lift $ assertEqual "9 / 3 = 3" 3 res
+
+divideExceptionTest :: String -> ProtocolId -> Test
+divideExceptionTest pname protId =
+  mkServerTest pname "divide exception" protId $
+  (void . lift . evaluate =<< divide 1 0)
+    `catchThrift` \DivideByZero -> return ()
+
+-- Calculator function
+multiTest :: String -> ProtocolId -> Test
+multiTest pname protId = mkServerTest pname "multiple requests" protId $ do
+  put 100
+
+  r1 <- add 2 2
+  lift $ assertEqual "2 + 2 = 4" 4 r1
+
+  r2 <- divide 64 16
+  lift $ assertEqual "64 / 16 = 4" 4 r2
+
+  r3 <- get
+  lift $ assertEqual "put = get" 100 r3
+
+  r4 <- divide 100 10
+  lift $ assertEqual "100 / 10 = 10" 10 r4
+
+unimplementedTest :: String -> ProtocolId -> Test
+unimplementedTest pname protId =
+  mkServerTest pname "unimplemented test" protId $
+    unimplemented `catchThrift` \ApplicationException{} -> return ()
+
+-- Echo function
+echoTest :: String -> ProtocolId -> Test
+echoTest pname protId = mkServerTest pname "echo" protId $ do
+  res <- echo val
+  lift $ assertEqual "echo echoed" val res
+  where
+    val = "AAAAAAAAAA_DO_NOT_DELETE"
+
+portAlreadyBoundTest :: String -> ProtocolId -> Test
+portAlreadyBoundTest pname protId =
+  TestLabel (pname ++ " portAlreadyBoundTest") $ TestCase $ do
+    (result :: Either SomeException ()) <- try $
+      withTestServer serverOptions $ const $ do
+        withHTTPChannel httpConfig $
+          lift $ withTestServer serverOptions $ const $ do
+            withHTTPChannel httpConfig $
+              return ()
+    assertBool "should fail" (isLeft result)
+  where
+    port :: Int
+    port = 9999
+    serverOptions :: ServerOptions
+    serverOptions = defaultOptions
+      { desiredPort = Just port
+      }
+    httpConfig :: HTTPConfig t
+    httpConfig = mkHTTPConfig port protId
+
+tests :: String -> ProtocolId -> [Test]
+tests pname protId = map (\f -> f pname protId)
+  [ addTest
+  , divideTest
+  , divideExceptionTest
+  , multiTest
+  , unimplementedTest
+  , echoTest
+  , portAlreadyBoundTest
+  ]
+
+main :: IO ()
+main = withFacebookUnitTest $
+  testRunner $ TestList $
+    tests "compact" compactProtocolId ++
+    tests "binary" binaryProtocolId

--- a/http/test/common/CalculatorHandler.hs
+++ b/http/test/common/CalculatorHandler.hs
@@ -1,0 +1,37 @@
+-- Copyright (c) Facebook, Inc. and its affiliates.
+
+module CalculatorHandler
+  ( calculatorHandler
+  , CalculatorState
+  , initCalcState
+  ) where
+
+import Control.Exception (throw)
+import Data.IORef
+import Thrift.Protocol.ApplicationException.Types
+
+import Math.Types
+import Math.Adder.Service
+import Math.Calculator.Service
+
+newtype CalculatorState = CalculatorState (IORef Int)
+
+initCalcState :: IO CalculatorState
+initCalcState = do
+  r <- newIORef 0
+  return $ CalculatorState r
+
+calculatorHandler :: CalculatorState -> CalculatorCommand a -> IO a
+calculatorHandler _ (SuperAdder (Add x y)) = return $ x + y
+calculatorHandler _ (Divide x y)
+  | y == 0    = throw DivideByZero
+  | otherwise = return $ x / y
+calculatorHandler (CalculatorState ref) (Put v) =
+  writeIORef ref (fromIntegral v)
+calculatorHandler (CalculatorState ref) (PutMany v) =
+  mapM_ (writeIORef ref . fromIntegral) v
+calculatorHandler (CalculatorState ref) Get =
+  fromIntegral <$> readIORef ref
+calculatorHandler _ Unimplemented =
+  throw $ ApplicationException "Unimplemented function"
+  ApplicationExceptionType_UnknownMethod

--- a/http/test/common/EchoHandler.hs
+++ b/http/test/common/EchoHandler.hs
@@ -1,0 +1,21 @@
+-- Copyright (c) Facebook, Inc. and its affiliates.
+
+module EchoHandler
+  ( echoHandler
+
+  , EchoerState
+  , initEchoerState
+  ) where
+
+import CalculatorHandler
+
+import Echoer.Echoer.Service
+
+newtype EchoerState = EchoerState CalculatorState
+
+initEchoerState :: IO EchoerState
+initEchoerState = EchoerState <$> initCalcState
+
+echoHandler :: EchoerState -> EchoerCommand a -> IO a
+echoHandler _ (Echo input) = return input
+echoHandler (EchoerState c) (SuperCalculator x) = calculatorHandler c x

--- a/http/thrift-http.cabal
+++ b/http/thrift-http.cabal
@@ -1,0 +1,143 @@
+cabal-version:       3.6
+
+-- Copyright (c) Facebook, Inc. and its affiliates.
+
+name:                thrift-http
+version:             0.1.0.0
+synopsis:            Support for Thrift-over-HTTP server and client
+homepage:            https://github.com/facebookincubator/hsthrift
+bug-reports:         https://github.com/facebookincubator/hsthrift/issues
+license:             BSD-3-Clause
+license-file:        LICENSE
+author:              Facebook, Inc.
+maintainer:          hsthrift-team@fb.com
+copyright:           (c) Facebook, All Rights Reserved
+category:            Thrift
+
+description:
+    Support for building servers and clients that communicate
+    using Thrift over an HTTP transport. Uses WAI and Warp as
+    the server-side HTTP implementation, and http-client for
+    the client-side implementation.
+    .
+    NOTE: for build instructions and documentation, see
+    https://github.com/facebookincubator/hsthrift
+
+source-repository head
+    type: git
+    location: https://github.com/facebookincubator/hsthrift.git
+
+common fb-haskell
+    default-language: Haskell2010
+    default-extensions:
+        BangPatterns
+        BinaryLiterals
+        DataKinds
+        DeriveDataTypeable
+        DeriveGeneric
+        EmptyCase
+        ExistentialQuantification
+        FlexibleContexts
+        FlexibleInstances
+        GADTs
+        GeneralizedNewtypeDeriving
+        LambdaCase
+        MultiParamTypeClasses
+        MultiWayIf
+        NoMonomorphismRestriction
+        OverloadedStrings
+        PatternSynonyms
+        RankNTypes
+        RecordWildCards
+        ScopedTypeVariables
+        StandaloneDeriving
+        TupleSections
+        TypeFamilies
+        TypeSynonymInstances
+        NondecreasingIndentation
+  if flag(opt)
+     ghc-options: -O2
+
+flag opt
+     default: False
+
+library
+  import: fb-haskell
+  exposed-modules:
+      Thrift.Server.HTTP
+      Thrift.Channel.HTTP
+
+  build-depends:
+      fb-util,
+      thrift-lib,
+      base >=4.11.1 && <4.15,
+      text ^>=1.2.3.0,
+      bytestring ^>=0.10.8.2,
+      async ^>=2.2.1,
+      utf8-string,
+      containers,
+      wai,
+      warp,
+      streaming-commons,
+      network,
+      http-client,
+      http-types
+
+  default-language:    Haskell2010
+
+flag tests_use_ipv4
+     description: Force tests to use IPV4 whenever bringing thrift clients/servers up
+     default: False
+     manual: True
+
+common test-deps
+  build-depends: aeson,
+                 base,
+                 bytestring,
+                 data-default,
+                 deepseq,
+                 fb-stubs,
+                 fb-util,
+                 hashable,
+                 hspec,
+                 hspec-contrib,
+                 ghc-prim,
+                 HUnit ^>= 1.6.1,
+                 STMonadTrans,
+                 text,
+                 thrift-lib,
+                 thrift-lib:test-helpers,
+                 transformers,
+                 unordered-containers
+  if flag(tests_use_ipv4)
+    -- for test/Network.hs
+    cpp-options: -DIPV4
+
+library test-lib
+  import: fb-haskell, test-deps
+  hs-source-dirs: test/common, test/gen-hs2
+  exposed-modules:
+        CalculatorHandler
+        EchoHandler
+        Echoer.Echoer.Client
+        Echoer.Echoer.Service
+        Echoer.Types
+        Math.Adder.Client
+        Math.Adder.Service
+        Math.Calculator.Client
+        Math.Calculator.Service
+        Math.Types
+  build-depends:
+        containers
+
+common test-common
+  import: test-deps
+  hs-source-dirs: test
+  build-depends: thrift-http:test-lib, thrift-http
+  ghc-options: -threaded
+
+test-suite server
+  import: fb-haskell, test-common
+  type: exitcode-stdio-1.0
+  main-is: ServerTest.hs
+  ghc-options: -main-is ServerTest


### PR DESCRIPTION
Support for building servers and clients that communicate using Thrift
over an HTTP transport, allowing Thrift to be used without a
dependency on fbthrift. Uses WAI and Warp as the server-side HTTP
implementation, and http-client for the client-side implementation.
