### PR TITLE
[hsthrift][getdeps] Add symlink for fbpython for build

### DIFF
--- a/new_install_deps.sh
+++ b/new_install_deps.sh
@@ -33,6 +33,17 @@ if [ -z "${INSTALL_PREFIX}" ]; then
     INSTALL_PREFIX="${HOME}/.hsthrift"
 fi
 
+
+if [ ! -d "${INSTALL_PREFIX}/bin" ]; then
+    mkdir -p ${INSTALL_PREFIX}/bin
+fi
+
+# getdeps.py assumes fbpython exists
+if [ ! -L "${INSTALL_PREFIX}/bin/fbpython" ]; then
+    ln -s $(which python3) ${INSTALL_PREFIX}/bin/fbpython
+fi
+export PATH=${PATH}:${INSTALL_PREFIX}/bin
+
 # build in order
 for dep in $DEPS; do
     ${BUILDER} build --no-deps --install-dir "${INSTALL_PREFIX}" \


### PR DESCRIPTION
Needed by getdeps now

see e.g.

```
run ./install_deps.sh
Cloning into 'hsthrift'...
rm -f glean.cabal
m4 -E -E -P .build/def/cxx/defs.m4 glean.cabal.in \
	| sed "/-- Copyright/a \\\n-- @""generated from glean.cabal.in\\n-- DO NO EDIT THIS FILE DIRECTLY" \
	> glean.cabal
chmod guo-w glean.cabal
/usr/bin/env: ‘fbpython’: No such file or directory
```