### PR TITLE
Allow building without folly, for Hackage release.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,4 +14,7 @@ packages:
 
 allow-newer: haskell-names:aeson, haskell-names:bytestring
 
+package fb-util
+  flags: +folly
+
 tests: true

--- a/ci-sdist.cabal.project
+++ b/ci-sdist.cabal.project
@@ -4,6 +4,9 @@ packages: */*.cabal
 
 allow-newer: haskell-names:aeson, haskell-names:bytestring
 
+package fb-util
+  flags: +folly
+
 tests: true
 -- IPV6 is disabled in the Github Actions environment,
 -- so we make sure the appropriate tests in those packages

--- a/ci.cabal.project
+++ b/ci.cabal.project
@@ -15,6 +15,9 @@ allow-newer: haskell-names:aeson, haskell-names:bytestring
 
 tests: true
 
+package fb-util
+  flags: +folly
+
 -- IPV6 is disabled in the Github Actions environment,
 -- so we make sure the appropriate tests in those packages
 -- turn to IPV4.

--- a/common/util/fb-util.cabal
+++ b/common/util/fb-util.cabal
@@ -61,6 +61,10 @@ common fb-haskell
 
 common fb-cpp
   cxx-options: -std=c++17
+  -- We use hsc2hs with C++ headers, so we need to compile the
+  -- generated code with g++. The hsc2hs-generated binary is linked
+  -- by ghc, because we depend on a Haskell package (mangle).
+  hsc2hs-options: --cc=g++ --lflag=-lstdc++ --cflag=-D__HSC2HS__=1 --cflag=-std=c++17
   if !flag(clang)
      cxx-options: -fcoroutines
   if arch(x86_64)
@@ -72,6 +76,18 @@ flag opt
      default: False
 
 flag clang
+     default: False
+
+-- Enable modules that depend on folly. Since folly normally needs to
+-- be built from source, it is an inconvenient dependency. Without
+-- folly we can still build thrift-compiler and the thrift-http
+-- transport; only thrift-cpp-channel requires folly.
+--
+-- Ideally we'd split fb-util into two (or more) packages, or
+-- sub-libraries. But that requires moving files around because the
+-- Haskell sources would need to be in distinct directories, which needs
+-- to be done in the upstream repository.
+flag folly
      default: False
 
 library
@@ -87,20 +103,6 @@ library
         Control.Trace.VLog
         Data.MovingAverageRateLimiter
         Data.RateLimiterMap
-        Foreign.CPP.Addressable
-        Foreign.CPP.Dynamic
-        Foreign.CPP.HsStruct
-        Foreign.CPP.HsStruct.HsArray
-        Foreign.CPP.HsStruct.HsOption
-        Foreign.CPP.HsStruct.HsSet
-        Foreign.CPP.HsStruct.HsStdTuple
-        Foreign.CPP.HsStruct.HsMap
-        Foreign.CPP.HsStruct.HsStdVariant
-        Foreign.CPP.HsStruct.Types
-        Foreign.CPP.HsStruct.Unsafe
-        Foreign.CPP.HsStruct.Utils
-        Foreign.CPP.Marshallable
-        Foreign.CPP.Marshallable.TH
         Util.ASan
         Util.Async
         Util.Aeson
@@ -120,8 +122,6 @@ library
         -- Util.Dll
         Util.Encoding
         Util.Err
-        Util.EventBase
-        Util.Executor
         Util.Fd
         Util.FFI
         Util.FilePath
@@ -132,7 +132,6 @@ library
         Util.HUnit
         Util.HashMap.Strict
         Util.IO
-        Util.IOBuf
         Util.JSON.Pretty
         Util.Lens
         Util.Linter
@@ -167,22 +166,12 @@ library
         Util.WBVar
 
     cxx-sources:
-        cpp/cdynamic.cpp
         cpp/ffi.cpp
         cpp/logging.cpp
-        cpp/HsStruct.cpp
-        cpp/IOBuf.cpp
-        cpp/EventBaseDataplane.cpp
-        cpp/Executor.cpp
         Util/AsanAlloc.cpp
         -- Util/GFlags.cpp
 
     install-includes:
-        cpp/HsOption.h
-        cpp/HsStdTuple.h
-        cpp/HsStdVariant.h
-        cpp/HsStruct.h
-        cpp/HsStructDefines.h
         cpp/ffi.h
         cpp/memory.h
         cpp/wrap.h
@@ -245,13 +234,48 @@ library
 
     build-tool-depends: hsc2hs:hsc2hs
 
-    -- We use hsc2hs with C++ headers, so we need to compile the
-    -- generated code with g++. The hsc2hs-generated binary is linked
-    -- by ghc, because we depend on a Haskell package (mangle).
-    hsc2hs-options: --cc=g++ --lflag=-lstdc++ --cflag=-D__HSC2HS__=1 --cflag=-std=c++17
+    pkgconfig-depends: libglog, libevent, fmt, gflags
+    if flag(folly)
+        extra-libraries: double-conversion
+    else
+        pkgconfig-depends: double-conversion
 
-    pkgconfig-depends: libfolly, libglog, libevent, fmt, gflags
-    extra-libraries: double-conversion
+    if flag(folly)
+        exposed-modules:
+            Foreign.CPP.Addressable
+            Foreign.CPP.HsStruct
+            Foreign.CPP.HsStruct.HsArray
+            Foreign.CPP.HsStruct.HsOption
+            Foreign.CPP.HsStruct.HsSet
+            Foreign.CPP.HsStruct.HsStdTuple
+            Foreign.CPP.HsStruct.HsMap
+            Foreign.CPP.HsStruct.HsStdVariant
+            Foreign.CPP.HsStruct.Unsafe
+            Foreign.CPP.HsStruct.Types
+            Foreign.CPP.HsStruct.Utils
+            Foreign.CPP.Marshallable
+            Foreign.CPP.Marshallable.TH
+            Foreign.CPP.Dynamic
+            Util.EventBase
+            Util.Executor
+            Util.IOBuf
+
+        install-includes:
+            cpp/HsOption.h
+            cpp/HsStdTuple.h
+            cpp/HsStdVariant.h
+            cpp/HsStruct.h
+            cpp/HsStructDefines.h
+
+        cxx-sources:
+            cpp/HsStruct.cpp
+            cpp/cdynamic.cpp
+            cpp/EventBaseDataplane.cpp
+            cpp/Executor.cpp
+            cpp/HsStruct.cpp
+            cpp/IOBuf.cpp
+
+        pkgconfig-depends: libfolly
 
 common test-common
   extra-libraries: stdc++
@@ -317,6 +341,8 @@ test-suite iobuf
   main-is: IOBufTest.hs
   ghc-options: -main-is IOBufTest
   cxx-sources: tests/IOBufTest.cpp
+  if !flag(folly)
+     buildable: False
 test-suite alloc-limit
   import: fb-haskell, fb-cpp, test-common
   type: exitcode-stdio-1.0
@@ -372,6 +398,8 @@ test-suite exception
   type: exitcode-stdio-1.0
   main-is: ExceptionTest.hs
   ghc-options: -main-is ExceptionTest
+  if !flag(folly)
+     buildable: False
 test-suite control-exception
   import: fb-haskell, fb-cpp, test-common
   type: exitcode-stdio-1.0
@@ -428,7 +456,9 @@ test-suite dynamic
   main-is: DynamicTest.hs
   cxx-sources: tests/DynamicHelper.cpp
   ghc-options: -main-is DynamicTest
-test-suite hs-struct
+  if !flag(folly)
+     buildable: False
+test-suite test-hs-struct
   import: fb-haskell, fb-cpp, test-common
   type: exitcode-stdio-1.0
   main-is: HsStructTest.hs
@@ -436,6 +466,8 @@ test-suite hs-struct
   cxx-sources: tests/HsStructHelper.cpp
   ghc-options: -main-is HsStructTest
   build-depends: extra
+  if !flag(folly)
+     buildable: False
 
 -- TODO: commented out because of a linker problem
 -- test-suite gflags

--- a/http/thrift-http.cabal
+++ b/http/thrift-http.cabal
@@ -20,6 +20,10 @@ description:
     the server-side HTTP implementation, and http-client for
     the client-side implementation.
     .
+    This transport is only compatible with itself. In particular, it
+    is *not* compatible with fbthrift or apache-thrift clients and
+    servers.
+    .
     NOTE: for build instructions and documentation, see
     https://github.com/facebookincubator/hsthrift
 


### PR DESCRIPTION
All packages except thrift-cpp-channel and thrift-server can be built without folly. Thrift is fully usable with the thrift-http transport; all tests pass.

Test plan:
cabal test thrift-compiler thrift-lib thrift-http