### PR TITLE
Build fast_float from source

### DIFF
--- a/.github/workflows/ci-getdeps.yml
+++ b/.github/workflows/ci-getdeps.yml
@@ -13,7 +13,7 @@ jobs:
         ghc: [8.6.5, 8.8.4, 8.10.7, 9.2.8]
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:25.04
+      image: ubuntu:24.04
       options: --security-opt=seccomp=unconfined
     env:
         LD_LIBRARY_PATH: "/github/home/.hsthrift/lib"
@@ -79,7 +79,6 @@ jobs:
           libxxhash-dev
           libgtest-dev
           libtinfo-dev
-          libfast-float-dev
 
       - name: Setup Haskell
         run: |

--- a/new_install_deps.sh
+++ b/new_install_deps.sh
@@ -14,7 +14,7 @@ THREADS=4
 # These are required source deps not satisifiable with common package systems
 # in topological order. You can pass additional deps on the command line.
 #
-BASE_DEPS="fmt folly"
+BASE_DEPS="fmt fast_float folly"
 FBTHRIFT_DEPS="fizz wangle mvfst fbthrift"
 EXTRA_DEPS=""
 


### PR DESCRIPTION
Folly requires a more up-to-date fast_float than the one in Ubuntu 24,
so CI is currently using Ubuntu 25. But a better solution is to build
fast_float from source, and then we can revert the CI to use Ubuntu 24, 
so that we're back on an LTS release.