### PR TITLE
Pass parsed sequence number from the Msg if one is available

### DIFF
--- a/lib/Thrift/Channel/SocketChannel/Server.hs
+++ b/lib/Thrift/Channel/SocketChannel/Server.hs
@@ -154,9 +154,9 @@ withServerIO p mport maxQueuedConns handler postProcess client  = do
             -- a command from it as well, potentially doing this several
             -- times, until either we're done or more input is needed to go
             -- further.
-            Right (Some cmd, leftover) -> do
+            Right ((msgSeqNum, Some cmd), leftover) -> do
               (response, mexc, _headers) <-
-                processCommand p seqNum handler postProcess cmd
+                processCommand p msgSeqNum handler postProcess cmd
               seqNum' <- counter
               case mexc of
                 Just (_exc, _blame) -> do


### PR DESCRIPTION
### Why
Currently the seqNum is hardcoded to be `0` in `http/Thrift/Server/HTTP.hs` and the parsed sequence number is being completely ignored when MsgBegin is parsed. This is causing essentially all non haskell thrift clients to fail when calling the Haskell thrift server since the sequence id is used to look up the relevant callbacks after a response is received from the thrift call.

### How
- Return the parsed cmd and seqNum in the Processors msgParser


### Testing Done
Verified that the thrift server now works with other language clients like go / nodejs using [Glean server](https://github.com/facebookincubator/Glean)