### PR TITLE
Builds with GHC 9.4.x

### DIFF
--- a/.github/workflows/ci-getdeps.yml
+++ b/.github/workflows/ci-getdeps.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: [8.6.5, 8.8.4, 8.10.7, 9.2.8]
+        ghc: [8.6.5, 8.8.4, 8.10.7, 9.2.8, 9.4.7]
     runs-on: ubuntu-latest
     container:
       image: ubuntu:24.04

--- a/README.md
+++ b/README.md
@@ -44,7 +44,23 @@ The repository contains the following packages:
 * [thrift-cpp-channel](cpp-channel), libraries for Thrift clients (using fbthrift)
 * [thrift-server](server), libraries for Thrift servers (using fbthrift)
 
-# Building and testing
+# Building from Hackage
+
+If you only want to use the HTTP transport (not fbthrift) then you can
+build the packages directly from Hackage; if not, go to the next
+section for instructions to build from the repository. All of the
+packages above are on Hackage except for `thrift-cpp-channel` and
+`thrift-server`.
+
+```
+$ cabal install thrift-compiler thrift-lib thrift-http
+```
+
+aren't on
+Hackage because they depend on fbthrift and can only be built from the
+repository; see the next section.
+
+# Building and testing from the repository
 
 The following instructions assume you want to use `fbthrift`. To omit
 the `fbthrift` dependency and use only the HTTP transport, follow the

--- a/common/github/fb-stubs.cabal
+++ b/common/github/fb-stubs.cabal
@@ -16,8 +16,10 @@ category:            Utilities
 build-type:          Simple
 
 description:
+    Stubs for dependencies of test code, used by hsthrift and Glean.
+
     NOTE: for build instructions, see
-    https://github.com/facebookincubator/hsthrift
+    <https://github.com/facebookincubator/hsthrift>
 
 source-repository head
     type: git

--- a/common/github/fb-stubs.cabal
+++ b/common/github/fb-stubs.cabal
@@ -3,7 +3,7 @@ cabal-version:       3.6
 -- Copyright (c) Facebook, Inc. and its affiliates.
 
 name:                fb-stubs
-version:             0.1.0.0
+version:             0.1.0.1
 synopsis:            Stubs for dependencies of test code
 homepage:            https://github.com/facebookincubator/hsthrift
 bug-reports:         https://github.com/facebookincubator/hsthrift/issues
@@ -62,5 +62,5 @@ library
         Facebook.Init
 
     build-depends:
-        base >=4.11.1.0 && <4.17,
+        base >=4.11.1.0 && <4.18,
         HUnit ^>= 1.6.1

--- a/common/mangle/mangle.cabal
+++ b/common/mangle/mangle.cabal
@@ -14,7 +14,28 @@ maintainer:          hsthrift-team@fb.com
 copyright:           (c) Facebook, All Rights Reserved
 category:            FFI
 build-type:          Simple
-extra-source-files:  CHANGELOG.md
+extra-doc-files:     CHANGELOG.md
+
+description:
+    Converts C++ type signatures to mangled symbol names.
+    This is useful for calling C++ functions via the FFI without using
+    @extern \"C\" { .. }@.
+
+    The library can be used with Template Haskell, so you can call C++
+    code directly from Haskell, e.g.
+
+    @
+    {-# LANGUAGE TemplateHaskell #-}
+    ...
+    import Mangle.TH
+    ...
+    $(mangle
+      "void glog_info(const char*, int, const char*)"
+      [d|
+        foreign import ccall
+          c_glog_info :: CString -> CInt -> CString -> IO ()
+      |])
+    @
 
 source-repository head
     type: git

--- a/common/mangle/mangle.cabal
+++ b/common/mangle/mangle.cabal
@@ -3,7 +3,7 @@ cabal-version:       3.6
 -- Copyright (c) Facebook, Inc. and its affiliates.
 
 name:                mangle
-version:             0.1.0.0
+version:             0.1.0.1
 synopsis:            Convert C++ type signatures to their mangled form
 homepage:            https://github.com/facebookincubator/hsthrift
 bug-reports:         https://github.com/facebookincubator/hsthrift/issues
@@ -45,10 +45,10 @@ library
   exposed-modules:     Mangle, Mangle.TH
   default-extensions:  LambdaCase, GeneralizedNewtypeDeriving
   build-depends:
-      base >=4.11.1.0 && <4.17,
+      base >=4.11.1.0 && <4.18,
       containers >=0.5.11.0 && <0.7,
       parsec ^>=3.1.13.0,
-      template-haskell >=2.13 && <2.19
+      template-haskell >=2.13 && <2.20
   default-language:    Haskell2010
 
 executable mangle
@@ -56,10 +56,10 @@ executable mangle
   other-modules:       Mangle
   default-extensions:  LambdaCase, GeneralizedNewtypeDeriving
   build-depends:
-      base >=4.11.1 && <4.17,
+      base >=4.11.1 && <4.18,
       containers >=0.5.11 && <0.7,
       parsec ^>=3.1.13.0,
-      template-haskell >=2.13 && <2.19
+      template-haskell >=2.13 && <2.20
   default-language:    Haskell2010
 
 test-suite mangle-test

--- a/common/util/CHANGELOG.md
+++ b/common/util/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for fb-util
 
+## 0.1.0.1 -- YYYY-mm-dd
+
+* Builds with GHC 9.4.x
+
 ## 0.1.0.0 -- YYYY-mm-dd
 
 * First version. Released on an unsuspecting world.

--- a/common/util/fb-util.cabal
+++ b/common/util/fb-util.cabal
@@ -3,7 +3,7 @@ cabal-version:       3.6
 -- Copyright (c) Facebook, Inc. and its affiliates.
 
 name:                fb-util
-version:             0.1.0.0
+version:             0.1.0.1
 synopsis:            Various utility libraries
 homepage:            https://github.com/facebookincubator/hsthrift
 bug-reports:         https://github.com/facebookincubator/hsthrift/issues
@@ -185,13 +185,13 @@ library
     build-depends:
         HUnit ^>= 1.6.1,
         QuickCheck >= 2.14.3 && < 2.15,
-        aeson < 2.1,
+        aeson < 2.2,
         aeson-pretty >= 0.8.10 && < 0.9,
         array ^>=0.5.2.0,
         async ^>=2.2.1,
         atomic-primops >= 0.8.8 && < 0.9,
         attoparsec >= 0.14.4 && < 0.15,
-        base >=4.11.1.0 && <4.17,
+        base >=4.11.1.0 && <4.18,
         binary ^>=0.8.5.1,
         bytestring >=0.10.8.2 && <0.12,
         bytestring-lexing >= 0.5.0 && < 0.6,
@@ -205,8 +205,8 @@ library
         exceptions >= 0.10.4 && < 0.11,
         extra >= 1.8 && < 1.9,
         filepath ^>=1.4.2,
-        ghc >= 8.6.5 && < 9.3,
-        ghci >=8.4.3 && <9.3,
+        ghc >= 8.6.5 && < 9.5,
+        ghci >=8.4.3 && <9.5,
         hashable >=1.2.7.0 && <1.5,
         haskell-src-exts >= 1.23.1 && < 1.24,
         integer-gmp >=1.0.2.0 && <1.2,
@@ -219,16 +219,16 @@ library
         optparse-applicative >= 0.18.1 && < 0.19,
         pretty ^>=1.1.3.6,
         prettyprinter >=1.2.1 && <1.8,
-        primitive < 0.8,
+        primitive < 0.9,
         process ^>=1.6.3.0,
         scientific >= 0.3.7 && < 0.4,
         some >= 1.0.6 && < 1.1,
         split ^>=0.2.3.3,
         stm >= 2.5.0 && < 2.6,
-        template-haskell >=2.13 && <2.19,
+        template-haskell >=2.13 && <2.20,
         text ^>=1.2.3.0,
-        text-show >= 3.10.5 && < 3.11,
-        time >=1.8.0.2 && <1.12,
+        text-show >= 3.10.5 && < 3.12,
+        time >=1.8.0.2 && <1.13,
         transformers ^>=0.5.5.0,
         unix ^>=2.7.2.2,
         unordered-containers ^>=0.2.9.0,

--- a/common/util/fb-util.cabal
+++ b/common/util/fb-util.cabal
@@ -14,15 +14,17 @@ maintainer:          hsthrift-team@fb.com
 copyright:           (c) Facebook, All Rights Reserved
 category:            Utilities
 build-type:          Simple
-extra-source-files:  CHANGELOG.md,
-                     cpp/*.h,
+extra-source-files:  cpp/*.h,
                      tests/DynamicHelper.h,
                      tests/HsStructHelper.h,
                      hsc.h
+extra-doc-files:     CHANGELOG.md
 
 description:
+    Utility libraries used by Meta projects, notably hsthrift and Glean.
+
     NOTE: for build instructions, see
-    https://github.com/facebookincubator/hsthrift
+    <https://github.com/facebookincubator/hsthrift>
 
 source-repository head
     type: git
@@ -56,8 +58,8 @@ common fb-haskell
         TypeFamilies
         TypeSynonymInstances
         NondecreasingIndentation
-  if flag(opt)
-     ghc-options: -O2
+    if flag(opt)
+       ghc-options: -O2
 
 common fb-cpp
   cxx-options: -std=c++17
@@ -181,56 +183,56 @@ library
     hs-source-dirs: .
 
     build-depends:
-        atomic-primops,
-        aeson < 2.1,
-        attoparsec,
-        bytestring-lexing,
-        clock,
-        concurrent-extra,
-        exceptions,
-        ghc,
         HUnit ^>= 1.6.1,
-        json,
-        lens,
-        lifted-base,
-        mangle,
-        monad-control,
-        primitive < 0.8,
-        text-show,
-        optparse-applicative,
-        extra,
-        aeson-pretty,
-        either,
-        QuickCheck,
-        scientific,
-        haskell-src-exts,
-        some,
-        stm,
+        QuickCheck >= 2.14.3 && < 2.15,
+        aeson < 2.1,
+        aeson-pretty >= 0.8.10 && < 0.9,
+        array ^>=0.5.2.0,
+        async ^>=2.2.1,
+        atomic-primops >= 0.8.8 && < 0.9,
+        attoparsec >= 0.14.4 && < 0.15,
         base >=4.11.1.0 && <4.17,
-        containers >=0.5.11 && <0.7,
-        text ^>=1.2.3.0,
-        ghci >=8.4.3 && <9.3,
         binary ^>=0.8.5.1,
         bytestring >=0.10.8.2 && <0.12,
-        hashable >=1.2.7.0 && <1.5,
-        unordered-containers ^>=0.2.9.0,
-        transformers ^>=0.5.5.0,
-        time >=1.8.0.2 && <1.12,
+        bytestring-lexing >= 0.5.0 && < 0.6,
+        clock >= 0.8.4 && < 0.9,
+        concurrent-extra >= 0.7.0 && < 0.8,
+        containers >=0.5.11 && <0.7,
+        data-default >= 0.8.0 && < 0.9,
         deepseq ^>=1.4.3.0,
-        filepath ^>=1.4.2,
-        async ^>=2.2.1,
-        split ^>=0.2.3.3,
         directory ^>=1.3.1.5,
-        unix ^>=2.7.2.2,
-        process ^>=1.6.3.0,
-        vector >=0.12.0.1 && <0.14,
-        pretty ^>=1.1.3.6,
-        template-haskell >=2.13 && <2.19,
+        either >= 5.0.2 && < 5.1,
+        exceptions >= 0.10.4 && < 0.11,
+        extra >= 1.8 && < 1.9,
+        filepath ^>=1.4.2,
+        ghc >= 8.6.5 && < 9.3,
+        ghci >=8.4.3 && <9.3,
+        hashable >=1.2.7.0 && <1.5,
+        haskell-src-exts >= 1.23.1 && < 1.24,
         integer-gmp >=1.0.2.0 && <1.2,
+        json >= 0.11 && < 0.12,
+        lens >= 5.3.3 && < 5.4,
+        lifted-base >= 0.2.3 && < 0.3,
+        mangle >= 0.1.0 && < 0.2,
+        monad-control >= 1.0.3 && < 1.1,
         mtl ^>=2.2.2,
-        array ^>=0.5.2.0,
+        optparse-applicative >= 0.18.1 && < 0.19,
+        pretty ^>=1.1.3.6,
         prettyprinter >=1.2.1 && <1.8,
-        data-default,
+        primitive < 0.8,
+        process ^>=1.6.3.0,
+        scientific >= 0.3.7 && < 0.4,
+        some >= 1.0.6 && < 1.1,
+        split ^>=0.2.3.3,
+        stm >= 2.5.0 && < 2.6,
+        template-haskell >=2.13 && <2.19,
+        text ^>=1.2.3.0,
+        text-show >= 3.10.5 && < 3.11,
+        time >=1.8.0.2 && <1.12,
+        transformers ^>=0.5.5.0,
+        unix ^>=2.7.2.2,
+        unordered-containers ^>=0.2.9.0,
+        vector >=0.12.0.1 && <0.14,
 
     build-tool-depends: hsc2hs:hsc2hs
 

--- a/compiler/CHANGELOG.md
+++ b/compiler/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for thrift-compiler
 
-## 0.1.0.0 -- YYYY-mm-dd
+## 0.1.0.1
+
+* Builds with GHC 9.4.x
+
+## 0.1.0.0
 
 * First version. Released on an unsuspecting world.

--- a/compiler/thrift-compiler.cabal
+++ b/compiler/thrift-compiler.cabal
@@ -23,9 +23,9 @@ extra-source-files:  CHANGELOG.md,
 
 description:
     A compiler from the Thrift Interface Definition Language (IDL) to Haskell.
-    .
+
     NOTE: for build instructions and documentation, see
-    https://github.com/facebookincubator/hsthrift
+    <https://github.com/facebookincubator/hsthrift>
 
 source-repository head
     type: git
@@ -90,17 +90,18 @@ library
         Thrift.Compiler.Plugins.Linter
 
     build-depends:
-        fb-util,
-        aeson,
-        aeson-pretty,
-        array,
-        extra,
-        some,
+        aeson >= 2.0.3 && < 2.1,
+        array >= 0.5.3 && < 0.6,
+        mtl >= 2.2.2 && < 2.3,
+        optparse-applicative >= 0.18.1 && < 0.19,
+        aeson-pretty >= 0.8.10 && < 0.9,
+        either >= 5.0.2 && < 5.1,
+        extra >= 1.8 && < 1.9,
+        fb-util >= 0.1.0 && < 0.2,
+        some >= 1.0.6 && < 1.1,
+        text-show >= 3.10.5 && < 3.11,
         haskell-src-exts >=1.20.3 && <1.24,
-        either,
-        optparse-applicative,
         haskell-names < 0.10,
-        text-show,
         base >=4.11.1 && <4.17,
         async ^>=2.2.1,
         filepath ^>=1.4.2,
@@ -110,15 +111,17 @@ library
         bytestring >=0.10.8.2 && <0.12,
         unordered-containers ^>=0.2.9.0,
         directory ^>=1.3.1.5,
-        pretty ^>=1.1.3.6,
-        mtl
+        pretty ^>=1.1.3.6
     build-tool-depends: alex:alex, happy:happy
 
 executable thrift-compiler
     import: fb-haskell
     hs-source-dirs: main
     main-is: Main.hs
-    build-depends: base, optparse-applicative, thrift-compiler
+    build-depends:
+        base >=4.11.1 && <4.17,
+        optparse-applicative >= 0.18.1 && < 0.19,
+        thrift-compiler
 
 test-suite thrift-compiler-tests
   import: fb-haskell

--- a/compiler/thrift-compiler.cabal
+++ b/compiler/thrift-compiler.cabal
@@ -3,7 +3,7 @@ cabal-version:       3.6
 -- Copyright (c) Facebook, Inc. and its affiliates.
 
 name:                thrift-compiler
-version:             0.1.0.0
+version:             0.1.0.1
 synopsis: A compiler from the Thrift Interface Definition Language (IDL) to Haskell
 homepage:            https://github.com/facebookincubator/hsthrift
 bug-reports:         https://github.com/facebookincubator/hsthrift/issues
@@ -90,7 +90,7 @@ library
         Thrift.Compiler.Plugins.Linter
 
     build-depends:
-        aeson >= 2.0.3 && < 2.1,
+        aeson >= 2.0.3 && < 2.2,
         array >= 0.5.3 && < 0.6,
         mtl >= 2.2.2 && < 2.3,
         optparse-applicative >= 0.18.1 && < 0.19,
@@ -102,7 +102,7 @@ library
         text-show >= 3.10.5 && < 3.11,
         haskell-src-exts >=1.20.3 && <1.24,
         haskell-names < 0.10,
-        base >=4.11.1 && <4.17,
+        base >=4.11.1 && <4.18,
         async ^>=2.2.1,
         filepath ^>=1.4.2,
         containers >=0.5.11 && <0.7,
@@ -119,7 +119,7 @@ executable thrift-compiler
     hs-source-dirs: main
     main-is: Main.hs
     build-depends:
-        base >=4.11.1 && <4.17,
+        base >=4.11.1 && <4.18,
         optparse-applicative >= 0.18.1 && < 0.19,
         thrift-compiler
 

--- a/cpp-channel/thrift-cpp-channel.cabal
+++ b/cpp-channel/thrift-cpp-channel.cabal
@@ -124,7 +124,7 @@ library
         atomic
 
     build-depends:
-        base >=4.11.1 && <4.17,
+        base >=4.11.1 && <4.18,
         thrift-lib,
         fb-util,
         text,

--- a/cpp-channel/thrift-cpp-channel.cabal
+++ b/cpp-channel/thrift-cpp-channel.cabal
@@ -28,7 +28,7 @@ description:
     implemented in C++ with the fbthrift infrastructure.
     .
     NOTE: for build instructions and documentation, see
-    https://github.com/facebookincubator/hsthrift
+    <https://github.com/facebookincubator/hsthrift>
 
 source-repository head
     type: git

--- a/haxl/thrift-haxl.cabal
+++ b/haxl/thrift-haxl.cabal
@@ -20,7 +20,7 @@ description:
     framework.
     .
     NOTE: for build instructions and documentation, see
-    https://github.com/facebookincubator/hsthrift
+    <https://github.com/facebookincubator/hsthrift>
 
 source-repository head
     type: git
@@ -60,11 +60,11 @@ library
     exposed-modules:
         Haxl.DataSource.Thrift
     build-depends:
-        thrift-lib,
+        thrift-lib ^>= 0.1.0.0,
         hashable >=1.2.7.0 && <1.5,
         haxl >= 2.1.2.0 && < 2.6,
         mtl ^>=2.2.2,
-        text-show,
+        text-show >= 3.10.5 && < 3.11,
         text ^>=1.2.3.0,
         transformers ^>=0.5.5.0,
         unordered-containers ^>=0.2.9.0,

--- a/haxl/thrift-haxl.cabal
+++ b/haxl/thrift-haxl.cabal
@@ -3,7 +3,7 @@ cabal-version:       3.6
 -- Copyright (c) Facebook, Inc. and its affiliates.
 
 name:                thrift-haxl
-version:             0.1.0.0
+version:             0.1.0.1
 synopsis:            Support for using Haxl with Thrift services
 homepage:            https://github.com/facebookincubator/hsthrift
 bug-reports:         https://github.com/facebookincubator/hsthrift/issues
@@ -68,4 +68,4 @@ library
         text ^>=1.2.3.0,
         transformers ^>=0.5.5.0,
         unordered-containers ^>=0.2.9.0,
-        base >=4.11.1 && <4.17,
+        base >=4.11.1 && <4.18,

--- a/http/thrift-http.cabal
+++ b/http/thrift-http.cabal
@@ -3,7 +3,7 @@ cabal-version:       3.6
 -- Copyright (c) Facebook, Inc. and its affiliates.
 
 name:                thrift-http
-version:             0.1.0.0
+version:             0.1.0.1
 synopsis:            Support for Thrift-over-HTTP server and client
 homepage:            https://github.com/facebookincubator/hsthrift
 bug-reports:         https://github.com/facebookincubator/hsthrift/issues
@@ -74,7 +74,7 @@ library
   build-depends:
       fb-util >= 0.1.0 && < 0.2,
       thrift-lib >= 0.1.0 && < 0.2,
-      base >=4.11.1 && <4.17,
+      base >=4.11.1 && <4.18,
       text ^>=1.2.3.0,
       bytestring >=0.10.8.2 && <0.12,
       async ^>=2.2.1,
@@ -98,8 +98,8 @@ flag tests_use_ipv4
 
 common test-deps
   build-depends:
-      base >=4.11.1 && <4.17,
-      aeson >= 2.0.3 && < 2.1,
+      base >=4.11.1 && <4.18,
+      aeson >= 2.0.3 && < 2.2,
       bytestring,
       data-default >= 0.8.0 && < 0.9,
       deepseq >= 1.4.4 && < 1.5,
@@ -108,7 +108,7 @@ common test-deps
       hashable >= 1.4.4 && < 1.5,
       hspec >= 2.11.11 && < 2.12,
       hspec-contrib >= 0.5.2 && < 0.6,
-      ghc-prim >= 0.5.3 && < 0.9,
+      ghc-prim >= 0.5.3 && < 0.10,
       HUnit ^>= 1.6.1,
       STMonadTrans >= 0.4.8 && < 0.5,
       text,

--- a/http/thrift-http.cabal
+++ b/http/thrift-http.cabal
@@ -19,13 +19,13 @@ description:
     using Thrift over an HTTP transport. Uses WAI and Warp as
     the server-side HTTP implementation, and http-client for
     the client-side implementation.
-    .
+
     This transport is only compatible with itself. In particular, it
     is *not* compatible with fbthrift or apache-thrift clients and
     servers.
-    .
+
     NOTE: for build instructions and documentation, see
-    https://github.com/facebookincubator/hsthrift
+    <https://github.com/facebookincubator/hsthrift>
 
 source-repository head
     type: git
@@ -59,8 +59,8 @@ common fb-haskell
         TypeFamilies
         TypeSynonymInstances
         NondecreasingIndentation
-  if flag(opt)
-     ghc-options: -O2
+    if flag(opt)
+       ghc-options: -O2
 
 flag opt
      default: False
@@ -72,20 +72,20 @@ library
       Thrift.Channel.HTTP
 
   build-depends:
-      fb-util,
-      thrift-lib,
+      fb-util >= 0.1.0 && < 0.2,
+      thrift-lib >= 0.1.0 && < 0.2,
       base >=4.11.1 && <4.17,
       text ^>=1.2.3.0,
       bytestring >=0.10.8.2 && <0.12,
       async ^>=2.2.1,
-      utf8-string,
-      containers,
-      wai,
-      warp,
-      streaming-commons,
-      network,
-      http-client,
-      http-types
+      utf8-string >= 1.0.2 && < 1.1,
+      containers >= 0.6 && < 0.7,
+      wai >= 3.2.4 && < 3.3,
+      warp >= 3.3.30 && < 3.5,
+      streaming-commons >= 0.2.3 && < 0.3,
+      network >= 3.2.7 && < 3.3,
+      http-client >= 0.7.18 && < 0.8,
+      http-types >= 0.12.4 && < 0.13
 
   default-language:    Haskell2010
 
@@ -97,24 +97,26 @@ flag tests_use_ipv4
      manual: True
 
 common test-deps
-  build-depends: aeson,
-                 base,
-                 bytestring,
-                 data-default,
-                 deepseq,
-                 fb-stubs,
-                 fb-util,
-                 hashable,
-                 hspec,
-                 hspec-contrib,
-                 ghc-prim,
-                 HUnit ^>= 1.6.1,
-                 STMonadTrans,
-                 text,
-                 thrift-lib,
-                 thrift-lib:test-helpers,
-                 transformers,
-                 unordered-containers
+  build-depends:
+      base >=4.11.1 && <4.17,
+      aeson >= 2.0.3 && < 2.1,
+      bytestring,
+      data-default >= 0.8.0 && < 0.9,
+      deepseq >= 1.4.4 && < 1.5,
+      fb-stubs >= 0.1.0 && < 0.2,
+      fb-util,
+      hashable >= 1.4.4 && < 1.5,
+      hspec >= 2.11.11 && < 2.12,
+      hspec-contrib >= 0.5.2 && < 0.6,
+      ghc-prim >= 0.5.3 && < 0.9,
+      HUnit ^>= 1.6.1,
+      STMonadTrans >= 0.4.8 && < 0.5,
+      text,
+      thrift-lib,
+      thrift-lib:test-helpers,
+      transformers >= 0.5.6 && < 0.6,
+      unordered-containers >= 0.2.20 && < 0.3
+
   if flag(tests_use_ipv4)
     -- for test/Network.hs
     cpp-options: -DIPV4

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for thrift-lib
 
-## 0.1.0.0 -- YYYY-mm-dd
+## 0.1.0.1
+
+* Builds with GHC 9.4.x
+
+## 0.1.0.0
 
 * First version. Released on an unsuspecting world.

--- a/lib/thrift-lib.cabal
+++ b/lib/thrift-lib.cabal
@@ -14,16 +14,16 @@ maintainer:          hsthrift-team@fb.com
 copyright:           (c) Facebook, All Rights Reserved
 category:            Thrift
 build-type:          Simple
-extra-source-files:  CHANGELOG.md,
-                     if/*.thrift,
+extra-source-files:  if/*.thrift,
                      test/if/*.thrift
+extra-doc-files:     CHANGELOG.md
 
 description:
     Support for building client and server applications that
     communicate using the Thrift protocols.
-    .
+
     NOTE: for build instructions and documentation, see
-    https://github.com/facebookincubator/hsthrift
+    <https://github.com/facebookincubator/hsthrift>
 
 source-repository head
     type: git
@@ -91,29 +91,34 @@ library
     extra-libraries: stdc++
 
     build-depends:
-        ghc-prim,
-        some,
-        containers,
-        deepseq,
-        STMonadTrans,
-        data-default,
-        fb-util,
-        bytestring-lexing,
-        scientific,
-        ghc,
-        aeson >= 1,
-        word8,
-        aeson-pretty,
-        text-show,
-        base >=4.11.1 && <4.17,
+        QuickCheck >= 2.14.3 && < 2.15,
+        STMonadTrans >= 0.4.8 && < 0.5,
+        aeson >= 1 && < 2.1,
+        aeson-pretty >= 0.8.10 && < 0.9,
         async ^>= 2.2,
-        transformers ^>=0.5.5.0,
+        base >=4.11.1 && <4.17,
         bytestring >=0.10.8.2 && <0.12,
-        network,
-        text ^>=1.2.3.0,
-        unordered-containers ^>=0.2.9.0,
+        bytestring-lexing >= 0.5.0 && < 0.6,
+        containers >= 0.6 && < 0.7,
+        data-default >= 0.8.0 && < 0.9,
+        deepseq >= 1.4.4 && < 1.5,
+        fb-stubs >= 0.1.0 && < 0.2,
+        fb-util >= 0.1.0 && < 0.2,
+        filepath >= 1.4.2 && < 1.5,
+        ghc >= 8.6.5 && < 9.3,
+        ghc-prim >= 0.5 && < 0.9,
         hashable >=1.2.7.0 && <1.5,
-        vector >=0.12.0.1 && < 0.14
+        hspec >= 2.11.11 && < 2.12,
+        hspec-contrib >= 0.5.2 && < 0.6,
+        network >= 3.2.7 && < 3.3,
+        scientific >= 0.3.7 && < 0.4,
+        some >= 1.0.6 && < 1.1,
+        text >= 1.2.3 && < 1.3,
+        text-show >= 3.10.5 && < 3.11,
+        transformers ^>=0.5.5.0,
+        unordered-containers >= 0.2.9.0 && < 0.3,
+        vector >= 0.12.0.1 && < 0.14,
+        word8 >= 0.1.3 && < 0.2
 
     if flag(tests_use_ipv4)
       -- for SocketChannel.hs
@@ -175,6 +180,7 @@ common test-deps
 -- This is used by local tests only
 library test-lib
   import: fb-haskell, test-deps
+  visibility: private
   hs-source-dirs:
         test/lib,
         test/gen-hs2,

--- a/lib/thrift-lib.cabal
+++ b/lib/thrift-lib.cabal
@@ -3,7 +3,7 @@ cabal-version:       3.6
 -- Copyright (c) Facebook, Inc. and its affiliates.
 
 name:                thrift-lib
-version:             0.1.0.0
+version:             0.1.0.1
 synopsis:            Libraries for Haskell Thrift
 homepage:            https://github.com/facebookincubator/hsthrift
 bug-reports:         https://github.com/facebookincubator/hsthrift/issues
@@ -93,10 +93,10 @@ library
     build-depends:
         QuickCheck >= 2.14.3 && < 2.15,
         STMonadTrans >= 0.4.8 && < 0.5,
-        aeson >= 1 && < 2.1,
+        aeson >= 1 && < 2.2,
         aeson-pretty >= 0.8.10 && < 0.9,
         async ^>= 2.2,
-        base >=4.11.1 && <4.17,
+        base >=4.11.1 && <4.18,
         bytestring >=0.10.8.2 && <0.12,
         bytestring-lexing >= 0.5.0 && < 0.6,
         containers >= 0.6 && < 0.7,
@@ -105,8 +105,8 @@ library
         fb-stubs >= 0.1.0 && < 0.2,
         fb-util >= 0.1.0 && < 0.2,
         filepath >= 1.4.2 && < 1.5,
-        ghc >= 8.6.5 && < 9.3,
-        ghc-prim >= 0.5 && < 0.9,
+        ghc >= 8.6.5 && < 9.5,
+        ghc-prim >= 0.5 && < 0.10,
         hashable >=1.2.7.0 && <1.5,
         hspec >= 2.11.11 && < 2.12,
         hspec-contrib >= 0.5.2 && < 0.6,

--- a/server/thrift-server.cabal
+++ b/server/thrift-server.cabal
@@ -3,7 +3,7 @@ cabal-version:       3.6
 -- Copyright (c) Facebook, Inc. and its affiliates.
 
 name:                thrift-server
-version:             0.1.0.0
+version:             0.1.0.1
 synopsis:            Support for creating Thrift servers in Haskell
 homepage:            https://github.com/facebookincubator/hsthrift
 bug-reports:         https://github.com/facebookincubator/hsthrift/issues
@@ -93,7 +93,7 @@ library
       fb-util,
       thrift-lib,
       thrift-cpp-channel,
-      base >=4.11.1 && <4.17,
+      base >=4.11.1 && <4.18,
       text ^>=1.2.3.0,
       bytestring >=0.10.8.2 && <0.12,
       async ^>=2.2.1,

--- a/server/thrift-server.cabal
+++ b/server/thrift-server.cabal
@@ -23,7 +23,7 @@ description:
     communicate using the Thrift protocols.
     .
     NOTE: for build instructions and documentation, see
-    https://github.com/facebookincubator/hsthrift
+    <https://github.com/facebookincubator/hsthrift>
 
 source-repository head
     type: git

--- a/tests/thrift-tests.cabal
+++ b/tests/thrift-tests.cabal
@@ -24,7 +24,7 @@ description:
     Tests for Haskell Thrift.
     .
     NOTE: for build instructions and documentation, see
-    https://github.com/facebookincubator/hsthrift
+    <https://github.com/facebookincubator/hsthrift>
 
 source-repository head
     type: git


### PR DESCRIPTION
- bounds bumped to allow building with GHC 9.4.x
- CI updated to include 9.4.7
- All packages bumped to 0.1.0.1
- Also includes commits from  #149 