### PR TITLE
Migrate OSS project to handle protocol split

### DIFF
--- a/build/fbcode_builder/CMake/FBThriftCppLibrary.cmake
+++ b/build/fbcode_builder/CMake/FBThriftCppLibrary.cmake
@@ -69,6 +69,8 @@ function(add_fbthrift_cpp_library LIB_NAME THRIFT_FILE)
     "${output_dir}/gen-cpp2/${base}_data.h"
     "${output_dir}/gen-cpp2/${base}_data.cpp"
     "${output_dir}/gen-cpp2/${base}_types.cpp"
+    "${output_dir}/gen-cpp2/${base}_types_compact.cpp"
+    "${output_dir}/gen-cpp2/${base}_types_binary.cpp"
     "${output_dir}/gen-cpp2/${base}_metadata.cpp"
   )
   foreach(service IN LISTS ARG_SERVICES)

--- a/cpp-channel/thrift-cpp-channel.cabal
+++ b/cpp-channel/thrift-cpp-channel.cabal
@@ -93,6 +93,8 @@ library
         if/gen-cpp2/RpcOptions_data.cpp
         if/gen-cpp2/RpcOptions_metadata.cpp
         if/gen-cpp2/RpcOptions_types.cpp
+        if/gen-cpp2/RpcOptions_types_compact.cpp
+        if/gen-cpp2/RpcOptions_types_binary.cpp
 
     hs-source-dirs: .
     build-tool-depends: hsc2hs:hsc2hs
@@ -156,6 +158,8 @@ test-suite header-channel
                test/if/gen-cpp2/AdderAsyncClient.cpp
                test/if/gen-cpp2/Adder.cpp
                test/if/gen-cpp2/math_types.cpp
+               test/if/gen-cpp2/math_types_compact.cpp
+               test/if/gen-cpp2/math_types_binary.cpp
                test/if/gen-cpp2/math_data.cpp
                test/if/gen-cpp2/math_metadata.cpp
   extra-libraries:

--- a/tests/thrift-tests.cabal
+++ b/tests/thrift-tests.cabal
@@ -195,6 +195,8 @@ test-suite integration
   include-dirs: .
   cxx-sources: cpp/hs_test.cpp
                if/gen-cpp2/hs_test_types.cpp
+               if/gen-cpp2/hs_test_types_compact.cpp
+               if/gen-cpp2/hs_test_types_binary.cpp
                if/gen-cpp2/hs_test_data.cpp
   ghc-options: -main-is IntegrationTest
 test-suite interaction
@@ -238,6 +240,8 @@ test-suite message
   include-dirs: .
   cxx-sources: cpp/messages.cpp
                if/gen-cpp2/hs_test_types.cpp
+               if/gen-cpp2/hs_test_types_compact.cpp
+               if/gen-cpp2/hs_test_types_binary.cpp
                if/gen-cpp2/hs_test_data.cpp
   ghc-options: -main-is MessageTest
 test-suite messed-up-case


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/CacheLib/pull/386

X-link: https://github.com/facebook/fb303/pull/67

fbthrift has moved compact/binary protocol instantiation outside _types.cpp (to _types_compact.cpp and _types_binary.cpp). We need to add these two files to the build system.

Differential Revision: D74687663


