### PR TITLE
Migrate OSS project to handle protocol split

### DIFF
--- a/cpp-channel/thrift-cpp-channel.cabal
+++ b/cpp-channel/thrift-cpp-channel.cabal
@@ -93,6 +93,8 @@ library
         if/gen-cpp2/RpcOptions_data.cpp
         if/gen-cpp2/RpcOptions_metadata.cpp
         if/gen-cpp2/RpcOptions_types.cpp
+        if/gen-cpp2/RpcOptions_types_compact.cpp
+        if/gen-cpp2/RpcOptions_types_binary.cpp
 
     hs-source-dirs: .
     build-tool-depends: hsc2hs:hsc2hs
@@ -156,6 +158,8 @@ test-suite header-channel
                test/if/gen-cpp2/AdderAsyncClient.cpp
                test/if/gen-cpp2/Adder.cpp
                test/if/gen-cpp2/math_types.cpp
+               test/if/gen-cpp2/math_types_compact.cpp
+               test/if/gen-cpp2/math_types_binary.cpp
                test/if/gen-cpp2/math_data.cpp
                test/if/gen-cpp2/math_metadata.cpp
   extra-libraries:


### PR DESCRIPTION
Summary: fbthrift has moved compact/binary protocol instantiation outside _types.cpp (to _types_compact.cpp and _types_binary.cpp). We need to add these two files to the build system.

Differential Revision: D74768490


