### PR TITLE
Strip leading zeroes in the folly-clib version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ setup-folly::
 # that respects Cabal's constraints on version numbers: no leading
 # zeroes and fields must be <10 digits.
 .PHONY: setup-folly-version setup-folly-0
-ver:=$(shell cd folly-clib/folly && date -u "--date=@$$(git log -1 --format=%ct)" +%Y%m%d.%-k%M)
+ver:=$(shell cd folly-clib/folly && date -u "--date=@$$(git log -1 --format=%ct)" +%Y%m%d.%-k%M | sed 's/\.0*/\./')
 setup-folly-version::
 	sed -i "s/^version:\(\s*\).*$$/version:\1$(ver)/" folly-clib/folly-clib.cabal 
 	sed -i "s/^\(\s*\)build-depends:\(\s*\)folly-clib\s*$$/\1build-depends: folly-clib==$(ver)/" common/util/fb-util.cabal


### PR DESCRIPTION
Cabal doesn't like leading zeroes.

Fixes this CI failure:
https://github.com/facebookincubator/hsthrift/actions/runs/16375702901/job/46274980740

```
Errors encountered when parsing cabal file folly-clib/folly-clib.cabal:

folly-clib/folly-clib.cabal:3:33: error:
unexpected Version digit with leading zero

    2 | name:               folly-clib
    3 | version:            20250718.056
      |                                 ^
```