### PR TITLE
folly-clib: switch to C++20

### DIFF
--- a/folly-clib/folly-clib.cabal.in
+++ b/folly-clib/folly-clib.cabal.in
@@ -31,7 +31,7 @@ source-repository head
   location: https://github.com/facebook/folly.git
 
 common fb-cpp
-  cxx-options: -std=c++17
+  cxx-options: -std=c++20
   if !flag(clang)
      cxx-options: -fcoroutines
   if arch(x86_64)


### PR DESCRIPTION
Fixes breakage in the Cabal-only CI job